### PR TITLE
SLING-8626 - Added Maven Model Version to generated POM, replace any …

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
@@ -143,7 +143,6 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
         return this;
     }
 
-
     public void convert(File...contentPackages) throws Exception {
         requireNonNull(contentPackages , "Null content-package(s) can not be converted.");
         secondPass(firstPass(contentPackages));
@@ -325,16 +324,20 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
     private static ArtifactId toArtifactId(VaultPackage vaultPackage) {
         PackageId packageId = vaultPackage.getId();
         String groupId = requireNonNull(packageId.getGroup(),
-                                        PackageProperties.NAME_GROUP
-                                        + " property not found in content-package "
-                                        + vaultPackage
-                                        + ", please check META-INF/vault/properties.xml").replace('/', '.'); 
+            PackageProperties.NAME_GROUP
+                + " property not found in content-package "
+                + vaultPackage
+                + ", please check META-INF/vault/properties.xml").replace('/', '.');
+        // Replace any space with an underscore to adhere to Maven Group Id specification
+        groupId = groupId.replaceAll(" ", "_");
 
         String artifactid = requireNonNull(packageId.getName(),
-                                           PackageProperties.NAME_NAME
-                                           + " property not found in content-package "
-                                           + vaultPackage
-                                           + ", please check META-INF/vault/properties.xml");
+            PackageProperties.NAME_NAME
+                + " property not found in content-package "
+                + vaultPackage
+                + ", please check META-INF/vault/properties.xml");
+        // Replace any space with an underscore to adhere to Maven Artifact Id specification
+        artifactid = artifactid.replaceAll(" ", "_");
 
         String version = packageId.getVersionString();
         if (version == null || version.isEmpty()) {

--- a/src/main/java/org/apache/sling/feature/cpconverter/artifacts/MavenPomSupplierWriter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/artifacts/MavenPomSupplierWriter.java
@@ -34,6 +34,8 @@ public final class MavenPomSupplierWriter implements ArtifactWriter {
     @Override
     public void write(OutputStream outputStream) throws IOException {
         Model model = new Model();
+        // Maven complains if Model Version is not set
+        model.setModelVersion("4.0.0");
         model.setGroupId(id.getGroupId());
         model.setArtifactId(id.getArtifactId());
         model.setVersion(id.getVersion());

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/BundleEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/BundleEntryHandler.java
@@ -81,7 +81,11 @@ public final class BundleEntryHandler extends AbstractRegexEntryHandler {
                 classifier = properties.getProperty(NAME_CLASSIFIER);
             } else { // maybe the included jar is just an OSGi bundle but not a valid Maven artifact
                 groupId = getCheckedProperty(manifest, BUNDLE_SYMBOLIC_NAME);
+                // Make sure there are not spaces in the name to adhere to the Maven Group Id specification
+                groupId = groupId.replaceAll(" ", "_");
                 artifactId = getCheckedProperty(manifest, BUNDLE_NAME);
+                // Make sure there are not spaces in the name to adhere to the Maven Artifact Id specification
+                artifactId = artifactId.replaceAll(" ", "_");
                 version = getCheckedProperty(manifest, BUNDLE_VERSION);
             }
         }


### PR DESCRIPTION
…spaces in Group and Artifact Ids
These fixes are here to fix issues with the conversion of CPs without a Maven style names.
Also the Model Version was missing in generated POMs causing some warnings.