### PR TITLE
SLING-9728 - Conversion fails for JSON configurations with type conversions: ClassNotFoundException: org.osgi.util.function.Function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.function</artifactId>
       <version>1.0.0</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>


### PR DESCRIPTION
Mark the org.osgi.util.function package as 'provided', to make sure it ends up
in the assembly. The dependency scope was either an accident, or a leftover
from when the configadmin did not require org.osgi.util.function.