### PR TITLE
SLING-9827 Specify the API Region to export packages into

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,13 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.feature</artifactId>
-      <version>1.2.4</version>
+      <version>1.2.10</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.feature.extension.apiregions</artifactId>
+      <version>1.1.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/sling/feature/cpconverter/cli/ContentPackage2FeatureModelConverterLauncher.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/cli/ContentPackage2FeatureModelConverterLauncher.java
@@ -83,6 +83,9 @@ public final class ContentPackage2FeatureModelConverterLauncher implements Runna
     @Option(names = { "-r", "--api-region" }, description = "The API Regions assigned to the generated features", required = false)
     private List<String> apiRegions;
 
+    @Option(names = { "-e", "--exports-to-region" }, description = "Packages exported by bundles in the content packages are exported in the named region", required = false)
+    private String exportsToRegion;
+
     @Option(names = {"-D", "--define"}, description = "Define a system property", required = false)
     private Map<String, String> properties = new HashMap<>();
 
@@ -131,6 +134,9 @@ public final class ContentPackage2FeatureModelConverterLauncher implements Runna
                                                             properties);
             if (apiRegions != null)
                 featuresManager.setAPIRegions(apiRegions);
+
+            if (exportsToRegion != null)
+                featuresManager.setExportToAPIRegion(exportsToRegion);
 
             ContentPackage2FeatureModelConverter converter = new ContentPackage2FeatureModelConverter(strictValidation)
                                                              .setFeaturesManager(featuresManager)

--- a/src/main/java/org/apache/sling/feature/cpconverter/features/DefaultFeaturesManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/features/DefaultFeaturesManager.java
@@ -23,12 +23,14 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.apache.sling.feature.Artifact;
 import org.apache.sling.feature.ArtifactId;
@@ -46,8 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DefaultFeaturesManager implements FeaturesManager {
-
-    private static final String JAVA_IO_TMPDIR_PROPERTY = "java.io.tmpdir";
 
     private static final String CONTENT_PACKAGES = "content-packages";
 
@@ -67,6 +67,8 @@ public class DefaultFeaturesManager implements FeaturesManager {
 
     private final File featureModelsOutputDirectory;
 
+    private final Map<String, List<String>> apiRegionExports = new HashMap<>();
+
     private final String artifactIdOverride;
 
     private final String prefix;
@@ -75,10 +77,16 @@ public class DefaultFeaturesManager implements FeaturesManager {
 
     private final List<String> targetAPIRegions = new ArrayList<>();
 
+    private String exportsToAPIRegion = null;
+
     private Feature targetFeature = null;
 
-    public DefaultFeaturesManager() {
-        this(true, 20, new File(System.getProperty(JAVA_IO_TMPDIR_PROPERTY)), null, null, null);
+    DefaultFeaturesManager() {
+        this(null);
+    }
+
+    public DefaultFeaturesManager(File tempDir) {
+        this(true, 20, tempDir, null, null, null);
     }
 
     public DefaultFeaturesManager(boolean mergeConfigurations,
@@ -99,27 +107,7 @@ public class DefaultFeaturesManager implements FeaturesManager {
     public void init(String groupId, String artifactId, String version) {
         targetFeature = new Feature(new ArtifactId(groupId, artifactId, version, null, SLING_OSGI_FEATURE_TILE_TYPE));
 
-        initAPIRegions(targetFeature);
-
         runModes.clear();
-    }
-
-    private void initAPIRegions(Feature feature) {
-        if (targetAPIRegions.size() > 0) {
-            Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
-            StringBuilder jsonBuilder = new StringBuilder("[");
-            for (String apiRegion : targetAPIRegions) {
-                if (jsonBuilder.length() > 1) {
-                    jsonBuilder.append(',');
-                }
-                jsonBuilder.append("{\"name\":\"");
-                jsonBuilder.append(apiRegion);
-                jsonBuilder.append("\",\"exports\":[]}");
-            }
-            jsonBuilder.append("]");
-            apiRegions.setJSON(jsonBuilder.toString());
-            feature.getExtensions().add(apiRegions);
-        }
     }
 
     @Override
@@ -141,7 +129,6 @@ public class DefaultFeaturesManager implements FeaturesManager {
 
         return runModes.computeIfAbsent(runMode, k -> {
             Feature f = new Feature(newId);
-            initAPIRegions(f);
             return f;
         });
     }
@@ -197,6 +184,18 @@ public class DefaultFeaturesManager implements FeaturesManager {
     }
 
     @Override
+    public void addAPIRegionExport(String runMode, String exportedPackage) {
+        if (exportsToAPIRegion == null)
+            return; // Ignore if we're not exporting to an API region
+
+
+        getRunMode(runMode); // Trigger runmode initialization
+
+        List<String> l = apiRegionExports.computeIfAbsent(runMode, r -> new ArrayList<>());
+        l.add(exportedPackage);
+    }
+
+    @Override
     public void addConfiguration(String runMode, String pid, Dictionary<String, Object> configurationProperties) {
         Feature feature = getRunMode(runMode);
         Configuration configuration = feature.getConfigurations().getConfiguration(pid);
@@ -225,6 +224,45 @@ public class DefaultFeaturesManager implements FeaturesManager {
         }
     }
 
+    private void addAPIRegions(Feature feature, List<String> exportedPackages) {
+        if (exportedPackages == null)
+            exportedPackages = Collections.emptyList();
+
+        if (exportedPackages.size() == 0 && targetAPIRegions.size() == 0)
+            return; // Nothing to do.
+
+        StringBuilder jsonBuilder = new StringBuilder("[");
+        if (exportsToAPIRegion != null) {
+            jsonBuilder.append("{\"name\":\"");
+            jsonBuilder.append(exportsToAPIRegion);
+            jsonBuilder.append("\",\"exports\":[");
+            jsonBuilder.append(exportedPackages
+                    .stream()
+                    .map(s -> '"' + s + '"')
+                    .collect(Collectors.joining(",")));
+            jsonBuilder.append("]}");
+        }
+
+        boolean first = true;
+        for (String apiRegion : targetAPIRegions) {
+            if (apiRegion.equals(exportsToAPIRegion))
+                continue; // We've handled that one already
+
+            if (exportsToAPIRegion != null || !first)
+                jsonBuilder.append(',');
+            first = false;
+
+            jsonBuilder.append("{\"name\":\"");
+            jsonBuilder.append(apiRegion);
+            jsonBuilder.append("\",\"exports\":[]}");
+        }
+        jsonBuilder.append(']');
+
+        Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+        apiRegions.setJSON(jsonBuilder.toString());
+        feature.getExtensions().add(apiRegions);
+    }
+
     @Override
     public void serialize() throws Exception {
         RunmodeMapper runmodeMapper = RunmodeMapper.open(featureModelsOutputDirectory);
@@ -242,6 +280,8 @@ public class DefaultFeaturesManager implements FeaturesManager {
     }
 
     private void serialize(Feature feature, String runMode, RunmodeMapper runmodeMapper) throws Exception {
+        addAPIRegions(feature, apiRegionExports.get(runMode));
+
         StringBuilder fileNameBuilder = new StringBuilder()
             .append((prefix != null) ? prefix : "")
             .append(feature.getId().getArtifactId());
@@ -284,6 +324,11 @@ public class DefaultFeaturesManager implements FeaturesManager {
     public synchronized DefaultFeaturesManager setAPIRegions(List<String> regions) {
         targetAPIRegions.clear();
         targetAPIRegions.addAll(regions);
+        return this;
+    }
+
+    public synchronized DefaultFeaturesManager setExportToAPIRegion(String region) {
+        exportsToAPIRegion = region;
         return this;
     }
 

--- a/src/main/java/org/apache/sling/feature/cpconverter/features/FeaturesManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/features/FeaturesManager.java
@@ -33,6 +33,8 @@ public interface FeaturesManager {
 
     void addArtifact(String runMode, ArtifactId id, Integer startOrder);
 
+    void addAPIRegionExport(String runMode, String exportedPackage);
+
     void addConfiguration(String runMode, String pid, Dictionary<String, Object> configurationProperties);
 
     void serialize() throws Exception;

--- a/src/test/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverterTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverterTest.java
@@ -307,11 +307,13 @@ public class ContentPackage2FeatureModelConverterTest {
 
                 JsonObject globalJO = ja.getJsonObject(0);
                 assertEquals("global", globalJO.getString("name"));
-                assertEquals(0, globalJO.getJsonArray("exports").size());
+                JsonArray globalExports = globalJO.getJsonArray("exports");
+                assertTrue(globalExports == null || globalExports.isEmpty());
 
                 JsonObject foobarJO = ja.getJsonObject(1);
                 assertEquals("foo.bar", foobarJO.getString("name"));
-                assertEquals(0, foobarJO.getJsonArray("exports").size());
+                JsonArray fooExports = foobarJO.getJsonArray("exports");
+                assertTrue(fooExports == null || fooExports.isEmpty());
             }
 
         } finally {
@@ -480,7 +482,8 @@ public class ContentPackage2FeatureModelConverterTest {
 
             JsonObject regionJO = ja.getJsonObject(0);
             assertEquals(region, regionJO.getString("name"));
-            assertEquals(0, regionJO.getJsonArray("exports").size());
+            JsonArray exports = regionJO.getJsonArray("exports");
+            assertTrue(exports == null || exports.isEmpty());
         }
     }
 

--- a/src/test/java/org/apache/sling/feature/cpconverter/features/FeaturesManagerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/features/FeaturesManagerTest.java
@@ -100,7 +100,7 @@ public class FeaturesManagerTest {
             JsonObject ar2 = ja.getJsonObject(1);
             assertEquals("deprecated", ar2.getString("name"));
             JsonArray are2 = ar2.getJsonArray("exports");
-            assertTrue(are2.isEmpty());
+            assertTrue(are2 == null || are2.isEmpty());
         }
 
         // Runmode file:
@@ -123,7 +123,7 @@ public class FeaturesManagerTest {
             JsonObject ar2 = ja.getJsonObject(1);
             assertEquals("deprecated", ar2.getString("name"));
             JsonArray are2 = ar2.getJsonArray("exports");
-            assertTrue(are2.isEmpty());
+            assertTrue(are2 == null || are2.isEmpty());
         }
     }
 }

--- a/src/test/java/org/apache/sling/feature/cpconverter/features/FeaturesManagerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/features/FeaturesManagerTest.java
@@ -20,18 +20,44 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FeaturesManagerTest {
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.stream.JsonParser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FeaturesManagerTest {
     private FeaturesManager featuresManager;
+    private Path tempDir;
 
     @Before
-    public void setUp() {
-        featuresManager = new DefaultFeaturesManager();
+    public void setUp() throws IOException {
+        tempDir = Files.createTempDirectory(getClass().getSimpleName());
+        featuresManager = new DefaultFeaturesManager(tempDir.toFile());
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         featuresManager = null;
+
+        // Delete the temp dir again
+        Files.walk(tempDir)
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -44,4 +70,60 @@ public class FeaturesManagerTest {
         featuresManager.addArtifact(null, null);
     }
 
+    @Test
+    public void testExportsToAPIRegion() throws Exception {
+        ((DefaultFeaturesManager) featuresManager).setExportToAPIRegion("global");
+        ((DefaultFeaturesManager) featuresManager).setAPIRegions(Collections.singletonList("deprecated"));
+        featuresManager.init("g", "a", "1");
+        featuresManager.addAPIRegionExport(null, "org.foo.a");
+        featuresManager.addAPIRegionExport(null, "org.foo.b");
+        featuresManager.addAPIRegionExport("rm1", "x.y");
+
+        featuresManager.serialize();
+
+        try (InputStream in = new FileInputStream(new File(tempDir.toFile(), "a.json"))) {
+            JsonParser p = Json.createParser(in);
+            JsonObject jo = p.getObject();
+
+            assertEquals("g:a:slingosgifeature:1", jo.getString("id"));
+
+            JsonArray ja = jo.getJsonArray("api-regions:JSON|false");
+            assertEquals(2, ja.size());
+
+            JsonObject ar1 = ja.getJsonObject(0);
+            assertEquals("global", ar1.getString("name"));
+            JsonArray are1 = ar1.getJsonArray("exports");
+
+            assertEquals(Arrays.asList("org.foo.a", "org.foo.b"),
+                    are1.getValuesAs(JsonString::getString));
+
+            JsonObject ar2 = ja.getJsonObject(1);
+            assertEquals("deprecated", ar2.getString("name"));
+            JsonArray are2 = ar2.getJsonArray("exports");
+            assertTrue(are2.isEmpty());
+        }
+
+        // Runmode file:
+        try (InputStream in = new FileInputStream(new File(tempDir.toFile(), "a-rm1.json"))) {
+            JsonParser p = Json.createParser(in);
+            JsonObject jo = p.getObject();
+
+            assertEquals("g:a:slingosgifeature:rm1:1", jo.getString("id"));
+
+            JsonArray ja = jo.getJsonArray("api-regions:JSON|false");
+            assertEquals(2, ja.size());
+
+            JsonObject ar1 = ja.getJsonObject(0);
+            assertEquals("global", ar1.getString("name"));
+            JsonArray are1 = ar1.getJsonArray("exports");
+
+            assertEquals(Arrays.asList("x.y"),
+                    are1.getValuesAs(JsonString::getString));
+
+            JsonObject ar2 = ja.getJsonObject(1);
+            assertEquals("deprecated", ar2.getString("name"));
+            JsonArray are2 = ar2.getJsonArray("exports");
+            assertTrue(are2.isEmpty());
+        }
+    }
 }


### PR DESCRIPTION
The region can be specified with the -e / --exports-to-region option.
Normally when this option is used the region specified with this option
would be the 'global' region or a region specific to the content
package.