### PR TITLE
SLING-9956 : RepPolicyEntryHandler ignores ACEs on repository level

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/RepPolicyEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/RepPolicyEntryHandler.java
@@ -30,10 +30,14 @@ import java.util.Stack;
 
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
 
-public final class RepPolicyEntryHandler extends AbstractPolicyEntryHandler {
+public class RepPolicyEntryHandler extends AbstractPolicyEntryHandler {
 
     public RepPolicyEntryHandler() {
         super("/jcr_root(.*/)_rep_policy.xml");
+    }
+
+    RepPolicyEntryHandler(@NotNull String regex) {
+        super(regex);
     }
 
     @NotNull
@@ -41,7 +45,7 @@ public final class RepPolicyEntryHandler extends AbstractPolicyEntryHandler {
         return new RepPolicyParser(repositoryPath, aclManager, handler);
     }
 
-    private static final class RepPolicyParser extends AbstractPolicyParser {
+    static final class RepPolicyParser extends AbstractPolicyParser {
 
         private static final String REP_ACL = "rep:ACL";
         private static final String REP_GRANT_ACE = "rep:GrantACE";

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/RepRepoPolicyEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/RepRepoPolicyEntryHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.feature.cpconverter.handlers;
+
+import org.apache.sling.feature.cpconverter.accesscontrol.AclManager;
+import org.apache.sling.feature.cpconverter.shared.RepoPath;
+import org.jetbrains.annotations.NotNull;
+
+import javax.xml.transform.sax.TransformerHandler;
+
+public class RepRepoPolicyEntryHandler extends RepPolicyEntryHandler {
+
+    public RepRepoPolicyEntryHandler() {
+        super("/jcr_root(/)_rep_repoPolicy.xml");
+    }
+
+    @Override
+    @NotNull AbstractPolicyParser createPolicyParser(@NotNull RepoPath repositoryPath, @NotNull AclManager aclManager, @NotNull TransformerHandler handler) {
+        return new RepPolicyParser(new RepoPath("") , aclManager, handler);
+    }
+}

--- a/src/main/java/org/apache/sling/feature/cpconverter/shared/RepoPath.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/shared/RepoPath.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
  */
 public class RepoPath implements Comparable<RepoPath>{
     private final List<String> path;
+    private final boolean isRepositoryPath;
 
     /**
      * Construct a Repo Path from a string. The string should separate the path
@@ -44,6 +45,8 @@ public class RepoPath implements Comparable<RepoPath>{
      */
     public RepoPath(@NotNull String path) {
         path = path.trim();
+        isRepositoryPath = path.isEmpty();
+
         if (path.startsWith("/"))
             path = path.substring(1);
 
@@ -58,6 +61,7 @@ public class RepoPath implements Comparable<RepoPath>{
      */
     public RepoPath(@NotNull List<String> list) {
         this.path = new ArrayList<>(list);
+        this.isRepositoryPath = false;
     }
 
     @Override
@@ -108,6 +112,10 @@ public class RepoPath implements Comparable<RepoPath>{
 
         List<String> l = new ArrayList<>(path.subList(0, otherPath.path.size()));
         return l.equals(otherPath.path);
+    }
+
+    public boolean isRepositoryPath() {
+        return isRepositoryPath;
     }
 
     @Override

--- a/src/main/resources/META-INF/services/org.apache.sling.feature.cpconverter.handlers.EntryHandler
+++ b/src/main/resources/META-INF/services/org.apache.sling.feature.cpconverter.handlers.EntryHandler
@@ -6,4 +6,5 @@ org.apache.sling.feature.cpconverter.handlers.NodeTypesEntryHandler
 org.apache.sling.feature.cpconverter.handlers.PrivilegesHandler
 org.apache.sling.feature.cpconverter.handlers.PropertiesConfigurationEntryHandler
 org.apache.sling.feature.cpconverter.handlers.RepPolicyEntryHandler
+org.apache.sling.feature.cpconverter.handlers.RepRepoPolicyEntryHandler
 org.apache.sling.feature.cpconverter.handlers.XmlConfigurationEntryHandler

--- a/src/test/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverterTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverterTest.java
@@ -63,6 +63,7 @@ import org.apache.sling.feature.cpconverter.artifacts.DefaultArtifactsDeployer;
 import org.apache.sling.feature.cpconverter.features.DefaultFeaturesManager;
 import org.apache.sling.feature.cpconverter.filtering.RegexBasedResourceFilter;
 import org.apache.sling.feature.cpconverter.handlers.DefaultEntryHandlersManager;
+import org.apache.sling.feature.cpconverter.handlers.EntryHandlersManager;
 import org.apache.sling.feature.cpconverter.vltpkg.DefaultPackagesEventsEmitter;
 import org.apache.sling.feature.io.json.FeatureJSONReader;
 import org.junit.After;
@@ -86,17 +87,25 @@ public class ContentPackage2FeatureModelConverterTest {
                                                                 "test_e-1.0.zip" };
 
     private ContentPackage2FeatureModelConverter converter;
+    private EntryHandlersManager handlersManager;
 
     @Before
     public void setUp() {
+        handlersManager = new DefaultEntryHandlersManager();
         converter = new ContentPackage2FeatureModelConverter()
-                    .setEntryHandlersManager(new DefaultEntryHandlersManager())
+                    .setEntryHandlersManager(handlersManager)
                     .setAclManager(new DefaultAclManager());
     }
 
     @After
     public void tearDowd() {
         converter = null;
+    }
+
+    @Test
+    public void testHandlersPresent() {
+        assertNotNull(handlersManager.getEntryHandlerByEntryPath("/jcr_root/_rep_policy.xml"));
+        assertNotNull(handlersManager.getEntryHandlerByEntryPath("/jcr_root/_rep_repoPolicy.xml"));
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/RepRepoPolicyEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/RepRepoPolicyEntryHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.cpconverter.handlers;
+
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.ExtensionType;
+import org.apache.sling.feature.cpconverter.accesscontrol.AclManager;
+import org.apache.sling.feature.cpconverter.accesscontrol.DefaultAclManager;
+import org.apache.sling.feature.cpconverter.accesscontrol.SystemUser;
+import org.apache.sling.feature.cpconverter.shared.RepoPath;
+import org.apache.sling.repoinit.parser.RepoInitParser;
+import org.apache.sling.repoinit.parser.impl.RepoInitParserService;
+import org.apache.sling.repoinit.parser.operations.Operation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class RepRepoPolicyEntryHandlerTest {
+
+    private RepPolicyEntryHandler handler;
+
+    @Before
+    public void setUp() {
+        handler = new RepRepoPolicyEntryHandler();
+    }
+
+    @After
+    public void tearDown() {
+        handler = null;
+    }
+
+    @Test
+    public void doesNotMatch() {
+        assertFalse(handler.matches("/this/is/a/path/not/pointing/to/a/valid/repoPolicy.xml"));
+        assertFalse(handler.matches("/this/is/a/path/not/pointing/to/a/valid/_rep_repoPolicy.xml"));
+    }
+
+    @Test
+    public void matches() {
+        assertTrue(handler.matches("/jcr_root/_rep_repoPolicy.xml"));
+    }
+
+    @Test
+    public void parsePolicy() throws Exception {
+        String path = "/jcr_root/_rep_repoPolicy.xml";
+        AclManager aclManager = new DefaultAclManager();
+        aclManager.addSystemUser(new SystemUser("repolevel-service", new RepoPath("/home/users/system/test"), new RepoPath("/home/users/system")));
+        Extension repoinitExtension = TestUtils.createRepoInitExtension(handler, aclManager, path, getClass().getResourceAsStream(path.substring(1)));
+
+        assertNotNull(repoinitExtension);
+        assertEquals(ExtensionType.TEXT, repoinitExtension.getType());
+        assertTrue(repoinitExtension.isRequired());
+
+        String expectedEnd =
+                "set ACL for repolevel-service" + System.lineSeparator() +
+                "allow jcr:namespaceManagement on :repository" + System.lineSeparator() +
+                "end" + System.lineSeparator();
+        String actual = repoinitExtension.getText();
+        assertTrue(actual.endsWith(expectedEnd));
+
+        RepoInitParser repoInitParser = new RepoInitParserService();
+        List<Operation> operations = repoInitParser.parse(new StringReader(actual));
+        assertFalse(operations.isEmpty());
+    }
+}

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/SystemUsersEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/SystemUsersEntryHandlerTest.java
@@ -21,25 +21,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
-import java.io.File;
-import java.util.Arrays;
 import java.io.StringReader;
 import java.util.List;
 
-import org.apache.jackrabbit.vault.fs.io.Archive;
-import org.apache.jackrabbit.vault.fs.io.Archive.Entry;
-import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionType;
-import org.apache.sling.feature.Feature;
-import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter;
 import org.apache.sling.feature.cpconverter.accesscontrol.DefaultAclManager;
-import org.apache.sling.feature.cpconverter.features.DefaultFeaturesManager;
-import org.apache.sling.feature.cpconverter.features.FeaturesManager;
-import org.apache.sling.feature.cpconverter.vltpkg.VaultPackageAssembler;
 import org.apache.sling.repoinit.parser.RepoInitParser;
 import org.apache.sling.repoinit.parser.impl.RepoInitParserService;
 import org.apache.sling.repoinit.parser.operations.Operation;
@@ -114,25 +102,6 @@ public class SystemUsersEntryHandlerTest {
     }
 
     private Extension parseAndSetRepoinit(String path) throws Exception {
-        Archive archive = mock(Archive.class);
-        Entry entry = mock(Entry.class);
-        VaultPackageAssembler packageAssembler = mock(VaultPackageAssembler.class);
-
-        when(archive.openInputStream(entry)).thenReturn(getClass().getResourceAsStream(path.substring(1)));
-
-        Feature feature = new Feature(new ArtifactId("org.apache.sling", "org.apache.sling.cp2fm", "0.0.1", null, null));
-        FeaturesManager featuresManager = spy(DefaultFeaturesManager.class);
-        when(featuresManager.getTargetFeature()).thenReturn(feature);
-        ContentPackage2FeatureModelConverter converter = spy(ContentPackage2FeatureModelConverter.class);
-        when(converter.getFeaturesManager()).thenReturn(featuresManager);
-        when(converter.getAclManager()).thenReturn(new DefaultAclManager());
-
-        systemUsersEntryHandler.handle(path, archive, entry, converter);
-
-        when(packageAssembler.getEntry(anyString())).thenReturn(new File("itdoesnotexist"));
-
-        converter.getAclManager().addRepoinitExtension(Arrays.asList(packageAssembler), featuresManager);
-        return feature.getExtensions().getByName(Extension.EXTENSION_NAME_REPOINIT);
+        return TestUtils.createRepoInitExtension(systemUsersEntryHandler, new DefaultAclManager(), path, getClass().getResourceAsStream(path.substring(1)));
     }
-
 }

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/TestUtils.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/TestUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.feature.cpconverter.handlers;
+
+import org.apache.jackrabbit.vault.fs.io.Archive;
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter;
+import org.apache.sling.feature.cpconverter.accesscontrol.AclManager;
+import org.apache.sling.feature.cpconverter.features.DefaultFeaturesManager;
+import org.apache.sling.feature.cpconverter.features.FeaturesManager;
+import org.apache.sling.feature.cpconverter.vltpkg.VaultPackageAssembler;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class TestUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(TestUtils.class);
+
+    private TestUtils() {}
+
+    static Extension createRepoInitExtension(@NotNull EntryHandler handler, @NotNull AclManager aclManager, @NotNull String path, @NotNull InputStream is) throws Exception {
+        Archive archive = mock(Archive.class);
+        Archive.Entry entry = mock(Archive.Entry.class);
+        VaultPackageAssembler packageAssembler = mock(VaultPackageAssembler.class);
+
+        when(archive.openInputStream(entry)).thenReturn(is);
+
+        Feature feature = new Feature(new ArtifactId("org.apache.sling", "org.apache.sling.cp2fm", "0.0.1", null, null));
+        FeaturesManager featuresManager = spy(DefaultFeaturesManager.class);
+        when(featuresManager.getTargetFeature()).thenReturn(feature);
+        ContentPackage2FeatureModelConverter converter = spy(ContentPackage2FeatureModelConverter.class);
+        when(converter.getFeaturesManager()).thenReturn(featuresManager);
+        when(converter.getAclManager()).thenReturn(aclManager);
+
+        handler.handle(path, archive, entry, converter);
+
+        when(packageAssembler.getEntry(anyString())).thenReturn(new File("itdoesnotexist"));
+
+        converter.getAclManager().addRepoinitExtension(Arrays.asList(packageAssembler), featuresManager);
+        return feature.getExtensions().getByName(Extension.EXTENSION_NAME_REPOINIT);
+    }
+}

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/_rep_repoPolicy.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/_rep_repoPolicy.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements. See the NOTICE file distributed with this
+ work for additional information regarding copyright ownership. The ASF
+ licenses this file to You under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+-->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+          jcr:primaryType="rep:ACL">
+    <allow
+            jcr:primaryType="rep:GrantACE"
+            rep:principalName="repolevel-service"
+            rep:privileges="{Name}[jcr:namespaceManagement]"/>
+</jcr:root>


### PR DESCRIPTION
@karlpauls , a few notes/questions regarding this PR (copied from jira):

- the regex in the new RepRepoPolicyEntryHandler looks a rather ugly to me.... if you have a better idea on how to do this without changing too much of the logic in RepPolicyEntryHandler, please let me know. in Oak the rep:repoPolicy can only occur at the root node but the call to `matcher.group(1)` in AbstractPolicyParser forces a group in the regex
- RepoPath: should isRepositoryPath be reflected in the equals/hashcode methods?
- DefaultAclManager: the method getRepoInitPath introduced in the patch has a param SystemUser which is not used yet.... but will it be needed for SLING-9692 and SLING-9953. since i derived the patch from some initial work done for those issues i decided to leave it in.
- TestUtils: i noticed that quite some test copy the logic on how to mock the fvault parts. i didn't yet replace all copies (just the one in the SystemUserHandlerTest). should i rather create a separate improvement for that?
