### PR TITLE
SLING-9953 : ACEs on/below user nodes are ignored upon conversion (tr…

### DIFF
--- a/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/AclManagerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/AclManagerTest.java
@@ -200,7 +200,7 @@ public class AclManagerTest {
         assertFalse(operations.isEmpty());
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void testGroupHandlingWithGroupUsed() {
         aclManager.addSystemUser(new SystemUser("sys-usr", new RepoPath("/home/users/system/foo"), new RepoPath("/home/users/system")));
 
@@ -216,18 +216,6 @@ public class AclManagerTest {
         aclManager.addRepoinitExtension(Collections.singletonList(assembler), fm);
 
         Extension repoinitExtension = feature.getExtensions().getByName(Extension.EXTENSION_NAME_REPOINIT);
-        assertNotNull(repoinitExtension);
-
-        String expected =
-                "create service user sys-usr with path /home/users/system" + System.lineSeparator() +
-                        "create group test with path /home/groups/test" + System.lineSeparator() +
-                        "set ACL for sys-usr" + System.lineSeparator() +
-                        "allow jcr:read on home(test)" + System.lineSeparator() +
-                        "end" + System.lineSeparator();
-
-        String actual = repoinitExtension.getText();
-        assertEquals(expected, actual);
-
     }
 
     @Test

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/RepPolicyEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/RepPolicyEntryHandlerTest.java
@@ -221,7 +221,7 @@ public final class RepPolicyEntryHandlerTest {
         assertTrue(result.getExcludedAcls().isEmpty());
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void policyAtGroupNode() throws Exception {
         SystemUser s1 = new SystemUser("service1", new RepoPath("/home/users/system/services/random1"), new RepoPath("/home/users/system/services"));
         Group gr = new Group("testgroup", new RepoPath("/home/groups/g/HjDnfdMCjekaF4jhhUvO"), new RepoPath("/home/groups/g"));
@@ -230,21 +230,7 @@ public final class RepPolicyEntryHandlerTest {
         aclManager.addSystemUser(s1);
         aclManager.addGroup(gr);
 
-        ParseResult result = parseAndSetRepoInit("/jcr_root/home/groups/g/HjDnfdMCjekaF4jhhUvO/_rep_policy.xml", aclManager);
-        Extension repoinitExtension = result.getRepoinitExtension();
-
-        String expected =
-                "create service user service1 with path /home/users/system/services" + System.lineSeparator() +
-                "create group testgroup with path /home/groups/g" + System.lineSeparator() +
-                "set ACL for service1" + System.lineSeparator() +
-                "allow jcr:read on home(testgroup)" + System.lineSeparator() +
-                "end" + System.lineSeparator();
-        assertEquals(expected, repoinitExtension.getText());
-
-        String expectedExclusions = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><jcr:root xmlns:jcr=\"http://www.jcp.org/jcr/1.0\" xmlns:rep=\"internal\" jcr:primaryType=\"rep:ACL\">\n" +
-                "    <allow1 jcr:primaryType=\"rep:GrantACE\" rep:principalName=\"testgroup\" rep:privileges=\"{Name}[jcr:read]\"/>\n" +
-                "</jcr:root>\n";
-        assertEquals(expectedExclusions, result.getExcludedAcls());
+        parseAndSetRepoInit("/jcr_root/home/groups/g/HjDnfdMCjekaF4jhhUvO/_rep_policy.xml", aclManager);
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
…eat groups the same as regular users and abort converter if ace points to them)