### PR TITLE
SLING-10070 : Option to enforce principal-based authorization (wip)

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/AclManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/AclManager.java
@@ -34,6 +34,8 @@ public interface AclManager {
 
     boolean addSystemUser(@NotNull SystemUser systemUser);
 
+    void addMapping(@NotNull Mapping mapping);
+
     boolean addAcl(@NotNull String systemUser, @NotNull AccessControlEntry acl);
 
     void addRepoinitExtension(@NotNull List<VaultPackageAssembler> packageAssemblers, @NotNull FeaturesManager featureManager);

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
@@ -27,6 +27,8 @@ import org.apache.sling.feature.cpconverter.shared.RepoPath;
 import org.apache.sling.feature.cpconverter.vltpkg.VaultPackageAssembler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jcr.NamespaceException;
 import java.io.File;
@@ -49,6 +51,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DefaultAclManager implements AclManager {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultAclManager.class);
 
     private static final String CONTENT_XML_FILE_NAME = ".content.xml";
 
@@ -145,7 +149,7 @@ public class DefaultAclManager implements AclManager {
         // created by repo-init statements generated here.
         Stream.concat(groups.stream(), users.stream()).forEach(abstractUser -> {
             if (aclStartsWith(abstractUser.getPath())) {
-                throw new IllegalStateException("Detected policy on user: " + abstractUser);
+                throw new IllegalStateException("Detected policy on user/group: " + abstractUser);
             }
         });
     }
@@ -238,6 +242,7 @@ public class DefaultAclManager implements AclManager {
             String id = systemUser.getId();
             for (Mapping mapping : mappings) {
                 if (mapping.mapsUser(id)) {
+                    log.info("Skip enforcing principalbased access control setup for system user {} due to '{}'", systemUser.getId(), mapping);
                     return false;
                 }
             }

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
@@ -179,7 +179,6 @@ public class DefaultAclManager implements AclManager {
                     Optional<SystemUser> su = getSystemUser(entry.getKey());
                     return su.isPresent() && !enforcePrincipalBased(su.get());
                 })
-                .filter(entry -> getSystemUser(entry.getKey()).isPresent())
                 .map(Entry::getValue)
                 .flatMap(Collection::stream)
                 // paths only should/need to be create with resource-based access control

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/Mapping.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/Mapping.java
@@ -34,7 +34,7 @@ public class Mapping {
     /**
      * Copied from https://github.com/apache/sling-org-apache-sling-serviceusermapper/blob/master/src/main/java/org/apache/sling/serviceusermapping/Mapping.java
      */
-    public Mapping(final String spec) {
+    public Mapping(@NotNull final String spec) {
 
         final int colon = spec.indexOf(':');
         final int equals = spec.indexOf('=');
@@ -68,7 +68,8 @@ public class Mapping {
     /**
      * Copied from https://github.com/apache/sling-org-apache-sling-serviceusermapper/blob/master/src/main/java/org/apache/sling/serviceusermapping/Mapping.java
      */
-    private static Set<String> extractPrincipalNames(String s) {
+    @NotNull
+    private static Set<String> extractPrincipalNames(@NotNull String s) {
         String[] sArr = s.substring(1, s.length() - 1).split(",");
         Set<String> set = new LinkedHashSet<>();
         for (String name : sArr) {

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/Mapping.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/Mapping.java
@@ -19,6 +19,7 @@ package org.apache.sling.feature.cpconverter.accesscontrol;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class Mapping {
@@ -87,5 +88,43 @@ public class Mapping {
 
     public boolean mapsPrincipal(@NotNull String principalName) {
         return this.principalNames != null && principalNames.contains(principalName);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hash(serviceName);
+        result = prime * result + Objects.hash(subServiceName);
+        result = prime * result + Objects.hash(userName);
+        result = prime * result + Objects.hash(principalNames);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        Mapping other = (Mapping) obj;
+        return Objects.equals(serviceName, other.serviceName)
+               && Objects.equals(subServiceName, other.subServiceName)
+               && Objects.equals(userName, other.userName)
+               && Objects.equals(principalNames, other.principalNames);
+    }
+
+    /**
+     * Copied from https://github.com/apache/sling-org-apache-sling-serviceusermapper/blob/master/src/main/java/org/apache/sling/serviceusermapping/Mapping.java
+     */
+    @Override
+    public String toString() {
+        String name = (userName != null) ? "userName=" + userName : "principleNames" + principalNames.toString();
+        return "Mapping [serviceName=" + serviceName + ", subServiceName="
+                + subServiceName + ", " + name;
     }
 }

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/Mapping.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/Mapping.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.feature.cpconverter.accesscontrol;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Mapping {
+
+    private final String serviceName;
+
+    private final String subServiceName;
+
+    private final String userName;
+
+    private final Set<String> principalNames;
+
+    /**
+     * Copied from https://github.com/apache/sling-org-apache-sling-serviceusermapper/blob/master/src/main/java/org/apache/sling/serviceusermapping/Mapping.java
+     */
+    public Mapping(final String spec) {
+
+        final int colon = spec.indexOf(':');
+        final int equals = spec.indexOf('=');
+
+        if (colon == 0 || equals <= 0) {
+            throw new IllegalArgumentException("serviceName is required");
+        } else if (equals == spec.length() - 1) {
+            throw new IllegalArgumentException("userName or principalNames is required");
+        } else if (colon + 1 == equals) {
+            throw new IllegalArgumentException("serviceInfo must not be empty");
+        }
+
+        if (colon < 0 || colon > equals) {
+            this.serviceName = spec.substring(0, equals);
+            this.subServiceName = null;
+        } else {
+            this.serviceName = spec.substring(0, colon);
+            this.subServiceName = spec.substring(colon + 1, equals);
+        }
+
+        String s = spec.substring(equals + 1);
+        if (s.charAt(0) == '[' && s.charAt(s.length()-1) == ']') {
+            this.userName = null;
+            this.principalNames = extractPrincipalNames(s);
+        } else {
+            this.userName = s;
+            this.principalNames = null;
+        }
+    }
+
+    /**
+     * Copied from https://github.com/apache/sling-org-apache-sling-serviceusermapper/blob/master/src/main/java/org/apache/sling/serviceusermapping/Mapping.java
+     */
+    private static Set<String> extractPrincipalNames(String s) {
+        String[] sArr = s.substring(1, s.length() - 1).split(",");
+        Set<String> set = new LinkedHashSet<>();
+        for (String name : sArr) {
+            String n = name.trim();
+            if (!n.isEmpty()) {
+                set.add(n);
+            }
+        }
+        return set;
+    }
+
+    public boolean mapsUser(@NotNull String userId) {
+        return userId.equals(this.userName);
+    }
+
+    public boolean mapsPrincipal(@NotNull String principalName) {
+        return this.principalNames != null && principalNames.contains(principalName);
+    }
+}

--- a/src/main/java/org/apache/sling/feature/cpconverter/cli/ContentPackage2FeatureModelConverterLauncher.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/cli/ContentPackage2FeatureModelConverterLauncher.java
@@ -96,11 +96,8 @@ public final class ContentPackage2FeatureModelConverterLauncher implements Runna
     @Option(names = { "-Z", "--fail-on-mixed-packages" }, description = "Fail the conversion if the resulting attached content-package is MIXED type", required = false)
     private boolean failOnMixedPackages = false;
 
-    @Option(names = { "--enforce-principal-based" }, description = "Converts all service user access control entries to principal-based setup", required = false)
-    private boolean enforcePrincipalBased = false;
-
-    @Option(names = { "--supported-principal-based-path" }, description = "Path supported for principal-based access control setup", required = false)
-    private String supportedPrincipalBasedPath = null;
+    @Option(names = { "--enforce-principal-based-supported-path" }, description = "Converts service user access control entries to principal-based setup using the given supported path.", required = false)
+    private String enforcePrincipalBasedSupportedPath = null;
 
     @Option(names = { "--entry-handler-config" }, description = "Config for entry handlers that support it (classname:<config-string>", required = false)
     private List<String> entryHandlerConfigs = null;
@@ -161,7 +158,7 @@ public final class ContentPackage2FeatureModelConverterLauncher implements Runna
                                                              .setFeaturesManager(featuresManager)
                                                              .setBundlesDeployer(new DefaultArtifactsDeployer(artifactsOutputDirectory))
                                                              .setEntryHandlersManager(new DefaultEntryHandlersManager(entryHandlerConfigsMap))
-                                                             .setAclManager(new DefaultAclManager(enforcePrincipalBased, supportedPrincipalBasedPath))
+                                                             .setAclManager(new DefaultAclManager(enforcePrincipalBasedSupportedPath))
                                                              .setEmitter(DefaultPackagesEventsEmitter.open(featureModelsOutputDirectory))
                                                              .setFailOnMixedPackages(failOnMixedPackages)
                                                              .setDropContent(true);

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/AbstractConfigurationEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/AbstractConfigurationEntryHandler.java
@@ -100,17 +100,10 @@ abstract class AbstractConfigurationEntryHandler extends AbstractRegexEntryHandl
             } else if ( REPOINIT_PID.equals(pid) ) {
                 checkReferences(configurationProperties, pid);
             } else if (pid.startsWith(SERVICE_USER_MAPPING_PID)) {
-                Object mappings = configurationProperties.get("user.mapping");
+                String[] mappings = Converters.standardConverter().convert(configurationProperties.get("user.mapping")).to(String[].class);
                 if (mappings != null) {
-                    String[] usermappings;
-                    if (mappings instanceof String[]) {
-                        usermappings = (String[]) mappings;
-                    } else {
-                        // FIXME
-                        throw new IllegalStateException(path + " => '" + mappings.toString() + "'");
-                    }
                     AclManager aclManager = Objects.requireNonNull(converter.getAclManager());
-                    for (String usermapping : usermappings) {
+                    for (String usermapping : mappings) {
                         aclManager.addMapping(new Mapping(usermapping));
                     }
                 }

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/AbstractConfigurationEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/AbstractConfigurationEntryHandler.java
@@ -24,6 +24,9 @@ import java.util.regex.Matcher;
 import org.apache.jackrabbit.vault.fs.io.Archive;
 import org.apache.jackrabbit.vault.fs.io.Archive.Entry;
 import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter;
+import org.apache.sling.feature.cpconverter.accesscontrol.AclManager;
+import org.apache.sling.feature.cpconverter.accesscontrol.Mapping;
+import org.apache.sling.feature.cpconverter.features.FeaturesManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.util.converter.Converters;
@@ -33,6 +36,8 @@ abstract class AbstractConfigurationEntryHandler extends AbstractRegexEntryHandl
     private static final String REPOINIT_FACTORY_PID = "org.apache.sling.jcr.repoinit.RepositoryInitializer";
 
     private static final String REPOINIT_PID = "org.apache.sling.jcr.repoinit.impl.RepositoryInitializer";
+
+    private static final String SERVICE_USER_MAPPING_PID = "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl";
 
     public AbstractConfigurationEntryHandler(@NotNull String extension) {
         super("/jcr_root/(?:apps|libs)/.+/config(\\.(?<runmode>[^/]+))?/(?<pid>.*)\\." + extension);
@@ -80,22 +85,38 @@ abstract class AbstractConfigurationEntryHandler extends AbstractRegexEntryHandl
             }
             // there is a specified RunMode
             runMode = matcher.group("runmode");
-            
+
+            FeaturesManager featuresManager = Objects.requireNonNull(converter.getFeaturesManager());
             if (REPOINIT_FACTORY_PID.equals(factoryPid)) {
                 final String[] scripts = Converters.standardConverter().convert(configurationProperties.get("scripts")).to(String[].class);
                 if (scripts != null && scripts.length > 0 ) {
                     for(final String text : scripts) {
                         if ( text != null && !text.trim().isEmpty() ) {
-                            Objects.requireNonNull(converter.getFeaturesManager()).addOrAppendRepoInitExtension(text, runMode);
+                            featuresManager.addOrAppendRepoInitExtension(text, runMode);
                         }
                     }
                 }
                 checkReferences(configurationProperties, pid);
             } else if ( REPOINIT_PID.equals(pid) ) {
                 checkReferences(configurationProperties, pid);
-
+            } else if (pid.startsWith(SERVICE_USER_MAPPING_PID)) {
+                Object mappings = configurationProperties.get("user.mapping");
+                if (mappings != null) {
+                    String[] usermappings;
+                    if (mappings instanceof String[]) {
+                        usermappings = (String[]) mappings;
+                    } else {
+                        // FIXME
+                        throw new IllegalStateException(path + " => '" + mappings.toString() + "'");
+                    }
+                    AclManager aclManager = Objects.requireNonNull(converter.getAclManager());
+                    for (String usermapping : usermappings) {
+                        aclManager.addMapping(new Mapping(usermapping));
+                    }
+                }
+                featuresManager.addConfiguration(runMode, id, configurationProperties);
             } else {
-                Objects.requireNonNull(converter.getFeaturesManager()).addConfiguration(runMode, id, configurationProperties);
+                featuresManager.addConfiguration(runMode, id, configurationProperties);
             }
         } else {
             throw new IllegalStateException("Something went terribly wrong: pattern '"

--- a/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/MappingTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/MappingTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.feature.cpconverter.accesscontrol;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MappingTest {
+
+    @Test
+    public void testMapUserId() {
+        Mapping m = new Mapping("org.apache.sling.testbundle:sub-service-1=service1");
+        assertTrue(m.mapsUser("service1"));
+        assertFalse(m.mapsUser("another"));
+        assertFalse(m.mapsPrincipal("service1"));
+        assertFalse(m.mapsPrincipal("another"));
+    }
+
+    @Test
+    public void testMapPrincipalNames() {
+        Mapping m = new Mapping("org.apache.sling.testbundle:sub-service-1=[service1,service2]");
+        assertFalse(m.mapsUser("service1"));
+        assertFalse(m.mapsUser("another"));
+        assertTrue(m.mapsPrincipal("service1"));
+        assertTrue(m.mapsPrincipal("service2"));
+        assertFalse(m.mapsPrincipal("another"));
+    }
+
+    @Test
+    public void testMapSinglePrincipalName() {
+        Mapping m = new Mapping("org.apache.sling.testbundle:sub-service-1=[service1]");
+        assertFalse(m.mapsUser("service1"));
+        assertFalse(m.mapsUser("another"));
+        assertTrue(m.mapsPrincipal("service1"));
+        assertFalse(m.mapsPrincipal("service2"));
+        assertFalse(m.mapsPrincipal("another"));
+    }
+
+    @Test
+    public void testMapEmptyPrincipalNames() {
+        Mapping m = new Mapping("org.apache.sling.testbundle:sub-service-1=[]");
+        assertFalse(m.mapsUser("service1"));
+        assertFalse(m.mapsUser("another"));
+        assertFalse(m.mapsPrincipal("service1"));
+        assertFalse(m.mapsPrincipal("service2"));
+        assertFalse(m.mapsPrincipal("another"));
+    }
+
+    @Test
+    public void testMapMissingSubservice() {
+        Mapping m = new Mapping("org.apache.sling.testbundle=[service1]");
+        assertFalse(m.mapsUser("service1"));
+        assertFalse(m.mapsUser("another"));
+        assertTrue(m.mapsPrincipal("service1"));
+        assertFalse(m.mapsPrincipal("another"));
+    }
+
+    @Test
+    public void testMapIncompleteArray() {
+        Mapping m = new Mapping("org.apache.sling.testbundle:sub-service=[service1");
+        assertTrue(m.mapsUser("[service1"));
+        assertFalse(m.mapsPrincipal("service1"));
+
+        m = new Mapping("org.apache.sling.testbundle:sub-service=service1]");
+        assertTrue(m.mapsUser("service1]"));
+        assertFalse(m.mapsPrincipal("service1"));
+    }
+
+    @Test
+    public void testColonInUserName() {
+        Mapping m = new Mapping("org.apache.sling.testbundle=sling:service1");
+        assertTrue(m.mapsUser("sling:service1"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingUser() {
+        new Mapping("org.apache.sling.testbundle:subservice");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingUser2() {
+        new Mapping("org.apache.sling.testbundle:sub-service=");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingBundle() {
+        new Mapping(":sub-service=[service1]");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingSubservice() {
+        new Mapping("org.apache.sling.testbundle:=service1");
+    }
+}

--- a/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/MappingTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/MappingTest.java
@@ -18,7 +18,9 @@ package org.apache.sling.feature.cpconverter.accesscontrol;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MappingTest {
@@ -106,5 +108,27 @@ public class MappingTest {
     @Test(expected = IllegalArgumentException.class)
     public void testMissingSubservice() {
         new Mapping("org.apache.sling.testbundle:=service1");
+    }
+
+    @Test
+    public void testEquals() {
+        Mapping m = new Mapping("org.apache.sling.testbundle:sub-service-1=service1");
+        Mapping m2 = new Mapping("org.apache.sling.testbundle:sub-service-1=[service1,service2]");
+        Mapping m3 = new Mapping("org.apache.sling.testbundle:sub-service-1=[service1]");
+
+        assertEquals(m, new Mapping("org.apache.sling.testbundle:sub-service-1=service1"));
+
+        assertNotEquals(m, new Mapping("org.apache.sling.testbundle=service1"));
+        assertNotEquals(m, new Mapping("org.apache.sling.testbundle:other-sub-service=service1"));
+        assertNotEquals(m, new Mapping("org.apache.sling.otherbundle:sub-service1=service1"));
+        assertNotEquals(m, m2);
+        assertNotEquals(m, m3);
+        assertNotEquals(m2, m3);
+        assertNotEquals(m2, new Mapping("org.apache.sling.testbundle:sub-service-1=[service3,service4]"));
+
+        assertTrue(m.equals(m));
+        assertTrue(m2.equals(m2));
+        assertFalse(m.equals(null));
+        assertFalse(m2.equals(m2.toString()));
     }
 }

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/ConfigurationEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/ConfigurationEntryHandlerTest.java
@@ -180,7 +180,7 @@ public class ConfigurationEntryHandlerTest {
             { path + EXPECTED_PID + ".config", 1, 2, 3, new ConfigurationEntryHandler(), null },
 
             { path + EXPECTED_PID + ".empty.xml", 1, 2, 0, new XmlConfigurationEntryHandler(), null },
-            { path + EXPECTED_PID + ".xml", 1, 2, 1, new XmlConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".xml", 1, 2, 3, new XmlConfigurationEntryHandler(), null },
 
             { path + EXPECTED_PID + ".empty.config.xml", 1, 2, 0, new XmlConfigurationEntryHandler(), null },
             { path + EXPECTED_PID + ".config.xml", 1, 2, 3, new XmlConfigurationEntryHandler(), null },

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/ConfigurationEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/ConfigurationEntryHandlerTest.java
@@ -87,6 +87,7 @@ public class ConfigurationEntryHandlerTest {
 
     private final int expectedConfigurationsSize;
     private final int expectedConfigurationsEntrySize;
+    private final int expectedMappings;
 
     private final AbstractConfigurationEntryHandler configurationEntryHandler;
     private final String expectedRunMode;
@@ -94,11 +95,13 @@ public class ConfigurationEntryHandlerTest {
     public ConfigurationEntryHandlerTest(String resourceConfiguration,
                                          int expectedConfigurationsSize,
                                          int expectedConfigurationsEntrySize,
+                                         int expectedMappings,
                                          AbstractConfigurationEntryHandler configurationEntryHandler, 
                                          String expectedRunMode) {
         this.resourceConfiguration = resourceConfiguration;
         this.expectedConfigurationsSize = expectedConfigurationsSize;
         this.expectedConfigurationsEntrySize = expectedConfigurationsEntrySize;
+        this.expectedMappings = expectedMappings;
         this.configurationEntryHandler = configurationEntryHandler;
         this.expectedRunMode = expectedRunMode;
     }
@@ -151,7 +154,7 @@ public class ConfigurationEntryHandlerTest {
                 assertTrue(props.isEmpty());
             } else {
                 assertEquals("Unmatching size: " + props.size(), expectedConfigurationsEntrySize, configuration.getProperties().size());
-                verify(aclManager, times(3)).addMapping(any(Mapping.class));
+                verify(aclManager, times(expectedMappings)).addMapping(any(Mapping.class));
             }
             // type & value check for typed configuration
             if (this.resourceConfiguration.equals(TYPED_TESTCONFIG_PATH)) {
@@ -167,32 +170,32 @@ public class ConfigurationEntryHandlerTest {
         String path = "/jcr_root/apps/asd/config/";
 
         return Arrays.asList(new Object[][] {
-            { path + EXPECTED_PID + ".empty.cfg", 1, 2, new PropertiesConfigurationEntryHandler(), null },
-            { path + EXPECTED_PID + ".cfg", 1, 2, new PropertiesConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".empty.cfg", 1, 2, 0, new PropertiesConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".cfg", 1, 2, 1, new PropertiesConfigurationEntryHandler(), null },
 
-            { path + EXPECTED_PID + ".empty.cfg.json", 1, 2, new JsonConfigurationEntryHandler(), null },
-            { path + EXPECTED_PID + ".cfg.json", 1, 2, new JsonConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".empty.cfg.json", 1, 2, 0, new JsonConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".cfg.json", 1, 2, 3, new JsonConfigurationEntryHandler(), null },
 
-            { path + EXPECTED_PID + ".empty.config", 1, 2, new ConfigurationEntryHandler(), null },
-            { path + EXPECTED_PID + ".config", 1, 2, new ConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".empty.config", 1, 2, 0, new ConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".config", 1, 2, 3, new ConfigurationEntryHandler(), null },
 
-            { path + EXPECTED_PID + ".empty.xml", 1, 2, new XmlConfigurationEntryHandler(), null },
-            { path + EXPECTED_PID + ".xml", 1, 2, new XmlConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".empty.xml", 1, 2, 0, new XmlConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".xml", 1, 2, 1, new XmlConfigurationEntryHandler(), null },
 
-            { path + EXPECTED_PID + ".empty.config.xml", 1, 2, new XmlConfigurationEntryHandler(), null },
-            { path + EXPECTED_PID + ".config.xml", 1, 2, new XmlConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".empty.config.xml", 1, 2, 0, new XmlConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".config.xml", 1, 2, 3, new XmlConfigurationEntryHandler(), null },
 
             
-            { path + EXPECTED_PID + ".empty.xml.cfg", 1, 2, new PropertiesConfigurationEntryHandler(), null },
-            { path + EXPECTED_PID + ".xml.cfg", 1, 2, new PropertiesConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".empty.xml.cfg", 1, 2, 0,  new PropertiesConfigurationEntryHandler(), null },
+            { path + EXPECTED_PID + ".xml.cfg", 1, 2, 1, new PropertiesConfigurationEntryHandler(), null },
 
             // runmode aware folders
-            { "/jcr_root/apps/asd/config.author/" + EXPECTED_PID + ".config", 1, 2, new ConfigurationEntryHandler(), "author" },
-            { REPOINIT_TESTCONFIG_PATH, 0, 2, new ConfigurationEntryHandler() , "author"},
-            { "/jcr_root/apps/asd/config.publish/" + EXPECTED_PID + ".config", 1, 2, new ConfigurationEntryHandler(), "publish" },
+            { "/jcr_root/apps/asd/config.author/" + EXPECTED_PID + ".config", 1, 2, 3, new ConfigurationEntryHandler(), "author" },
+            { REPOINIT_TESTCONFIG_PATH, 0, 2, 1, new ConfigurationEntryHandler() , "author"},
+            { "/jcr_root/apps/asd/config.publish/" + EXPECTED_PID + ".config", 1, 2, 3, new ConfigurationEntryHandler(), "publish" },
 
             //test typed config
-            { TYPED_TESTCONFIG_PATH, 1, 6, new XmlConfigurationEntryHandler(), null }
+            { TYPED_TESTCONFIG_PATH, 1, 6, 3, new XmlConfigurationEntryHandler(), null }
         });
     }
 

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/TestUtils.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/TestUtils.java
@@ -31,8 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.acl.Acl;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -49,6 +51,7 @@ class TestUtils {
     static Extension createRepoInitExtension(@NotNull EntryHandler handler, @NotNull AclManager aclManager, @NotNull String path, @NotNull InputStream is) throws Exception {
         return createRepoInitExtension(handler, aclManager, path, is, null);
     }
+
     static Extension createRepoInitExtension(@NotNull EntryHandler handler, @NotNull AclManager aclManager, @NotNull String path, @NotNull InputStream is, @Nullable OutputStream out) throws Exception {
         Archive archive = mock(Archive.class);
         Archive.Entry entry = mock(Archive.Entry.class);

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.author/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.author/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config
@@ -14,4 +14,4 @@
 # the License.
 
 user.default="admin"
-user.mapping=["com.adobe.acs.acs-aem-samples-bundle\=admin","com.adobe.acs.acs-aem-samples-bundle:sample-service\=oauthservice"]
+user.mapping=["org.apache.sling.testbundle:sub-service-1\=service1","org.apache.sling.testbundle:sub-service-2\=[service1,service2]","org.apache.sling.testbundle\=[service1,external-service-user]"]

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.publish/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.publish/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config
@@ -14,4 +14,4 @@
 # the License.
 
 user.default="admin"
-user.mapping=["com.adobe.acs.acs-aem-samples-bundle\=admin","com.adobe.acs.acs-aem-samples-bundle:sample-service\=oauthservice"]
+user.mapping=["org.apache.sling.testbundle:sub-service-1\=service1","org.apache.sling.testbundle:sub-service-2\=[service1,service2]","org.apache.sling.testbundle\=org.apache.sling.testbundle\=[service1,external-service-user]"]

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.cfg
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.cfg
@@ -14,4 +14,4 @@
 # the License.
 
 user.default=admin
-user.mapping=[org.apache.sling.testbundle:sub-service-1=service-1,org.apache.sling.testbundle:sub-service-2=[service1,service2],org.apache.sling.testbundle=[service1,external-service-user]]
+user.mapping=org.apache.sling.testbundle:sub-service-1=service-1

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.cfg
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.cfg
@@ -14,4 +14,4 @@
 # the License.
 
 user.default=admin
-user.mapping=[com.adobe.acs.acs-aem-samples-bundle=admin,com.adobe.acs.acs-aem-samples-bundle:sample-service=oauthservice]
+user.mapping=[org.apache.sling.testbundle:sub-service-1=service-1,org.apache.sling.testbundle:sub-service-2=[service1,service2],org.apache.sling.testbundle=[service1,external-service-user]]

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.cfg.json
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.cfg.json
@@ -1,7 +1,8 @@
 {
     "user.default":"admin",
     "user.mapping": [
-        "com.adobe.acs.acs-aem-samples-bundle=admin",
-        "com.adobe.acs.acs-aem-samples-bundle:sample-service=oauthservice"
+        "org.apache.sling.testbundle:sub-service-1=service1",
+        "org.apache.sling.testbundle:sub-service-2=[service1,service2]",
+        "org.apache.sling.testbundle=[service1,external-service-user]"
     ]
 }

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config
@@ -14,4 +14,4 @@
 # the License.
 
 user.default="admin"
-user.mapping=["com.adobe.acs.acs-aem-samples-bundle\=admin","com.adobe.acs.acs-aem-samples-bundle:sample-service\=oauthservice"]
+user.mapping=["org.apache.sling.testbundle:sub-service-1\=service1","org.apache.sling.testbundle:sub-service-2\=[service1,service2]","org.apache.sling.testbundle\=[service1,external-service-user]"]

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.config.xml
@@ -18,4 +18,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:OsgiConfig"
     user.default="admin"
-    user.mapping="[com.adobe.acs.acs-aem-samples-bundle=admin,com.adobe.acs.acs-aem-samples-bundle:sample-service=oauthservice]"/>
+    user.mapping="[org.apache.sling.testbundle:sub-service-1=service1,org.apache.sling.testbundle:sub-service-2=\[service1\,service2\],org.apache.sling.testbundle=\[service1\,external-service-user\]]"/>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.typed.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.typed.xml
@@ -22,4 +22,4 @@
     test.doubleproperty="{Double}1.23"
     test.dateproperty="{Date}2020-11-07T10:10:42.669"
     test.booleanproperty="{Boolean}true"
-    user.mapping="[com.adobe.acs.acs-aem-samples-bundle=admin,com.adobe.acs.acs-aem-samples-bundle:sample-service=oauthservice]"/>
+    user.mapping="[org.apache.sling.testbundle:sub-service-1=service1,org.apache.sling.testbundle:sub-service-2=\[service1\,service2\],org.apache.sling.testbundle=\[service1\,external-service-user\]]"/>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml
@@ -18,4 +18,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:OsgiConfig"
     user.default="admin"
-    user.mapping="[org.apache.sling.testbundle:sub-service-1=service1,org.apache.sling.testbundle:sub-service-2=\[service1\,service2\],org.apache.sling.testbundle=\[service1\,external-service-user\]]"/>
+    user.mapping="org.apache.sling.testbundle:sub-service-1=service1"/>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml
@@ -18,4 +18,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:OsgiConfig"
     user.default="admin"
-    user.mapping="[com.adobe.acs.acs-aem-samples-bundle=admin,com.adobe.acs.acs-aem-samples-bundle:sample-service=oauthservice]"/>
+    user.mapping="[org.apache.sling.testbundle:sub-service-1=service1,org.apache.sling.testbundle:sub-service-2=\[service1\,service2\],org.apache.sling.testbundle=\[service1\,external-service-user\]]"/>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml
@@ -18,4 +18,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:OsgiConfig"
     user.default="admin"
-    user.mapping="org.apache.sling.testbundle:sub-service-1=service1"/>
+    user.mapping="[org.apache.sling.testbundle:sub-service-1=service1,org.apache.sling.testbundle:sub-service-2=\[service1\,service2\],org.apache.sling.testbundle=\[service1\,external-service-user\]]"/>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml.cfg
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml.cfg
@@ -18,5 +18,5 @@
 -->
 <properties>
   <entry key="user.default">admin</entry>
-  <entry key="user.mapping">[com.adobe.acs.acs-aem-samples-bundle=admin,com.adobe.acs.acs-aem-samples-bundle:sample-service=oauthservice]</entry>
+  <entry key="user.mapping">[org.apache.sling.testbundle:sub-service-1=service1,org.apache.sling.testbundle:sub-service-2=[service1,service2],org.apache.sling.testbundle=[service1,external-service-user]]</entry>
 </properties>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml.cfg
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.xml.cfg
@@ -18,5 +18,5 @@
 -->
 <properties>
   <entry key="user.default">admin</entry>
-  <entry key="user.mapping">[org.apache.sling.testbundle:sub-service-1=service1,org.apache.sling.testbundle:sub-service-2=[service1,service2],org.apache.sling.testbundle=[service1,external-service-user]]</entry>
+  <entry key="user.mapping">org.apache.sling.testbundle:sub-service-1=service1</entry>
 </properties>


### PR DESCRIPTION
@karlpauls , some intial work for SLING-10070. the following pieces are not yet completed, some marked with TODO:
- parsing of *ServiceUserMapperImpl.*.cfg files returns a 'user.mapping' String and not a String array. i don't know if the problem is located with the test-files or if that is valid and needs extra parsing.... currently throws exception and is marked with TODO
- Mapping (and thus the parsing) is copied from sling service-user-mapping... i would prefer to avoid the code duplication if possible
- with the current flow in DefaultAclManager it will iterate multiple times over the mappings. 
- missing tests for those cases where principal-based ac setup cannot be enforced (single user mapping)
- the would default to enforce if there was no mapping defined in the content package.... we might to verify that this is a reasonable assumption or log an error if there is no mapping defined. wdyt?