### PR TITLE
SLING-10286 : Converter ignores disabled status of system user

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/AbstractUser.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/AbstractUser.java
@@ -18,6 +18,7 @@ package org.apache.sling.feature.cpconverter.accesscontrol;
 
 import org.apache.sling.feature.cpconverter.shared.RepoPath;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -27,6 +28,8 @@ abstract class AbstractUser {
 
     private final RepoPath path;
     private final RepoPath intermediatePath;
+    
+    private final String disabledReason;
 
     /**
      * @param id - the authorizableId to use.
@@ -34,9 +37,14 @@ abstract class AbstractUser {
      * @param intermediatePath - the intermediate path the user should have - most likely the (direct) parent of the path.
      */
     protected AbstractUser(@NotNull String id, @NotNull RepoPath path, @NotNull RepoPath intermediatePath) {
+        this(id, path, intermediatePath, null);
+    }
+
+    protected AbstractUser(@NotNull String id, @NotNull RepoPath path, @NotNull RepoPath intermediatePath, @Nullable String disabledReason) {
         this.id = id;
         this.path = path;
         this.intermediatePath = intermediatePath;
+        this.disabledReason = disabledReason;
     }
 
     public @NotNull String getId() {
@@ -49,6 +57,10 @@ abstract class AbstractUser {
 
     public @NotNull RepoPath getIntermediatePath() {
         return intermediatePath;
+    }
+    
+    public @Nullable String getDisabledReason() {
+        return disabledReason;
     }
 
     @Override

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
@@ -31,6 +31,7 @@ import org.apache.sling.feature.cpconverter.vltpkg.VaultPackageAssembler;
 import org.apache.sling.repoinit.parser.RepoInitParsingException;
 import org.apache.sling.repoinit.parser.impl.RepoInitParserService;
 import org.apache.sling.repoinit.parser.operations.CreateServiceUser;
+import org.apache.sling.repoinit.parser.operations.DisableServiceUser;
 import org.apache.sling.repoinit.parser.operations.Operation;
 import org.apache.sling.repoinit.parser.impl.WithPathOptions;
 import org.apache.sling.repoinit.parser.operations.AclLine;
@@ -217,6 +218,10 @@ public class DefaultAclManager implements AclManager, EnforceInfo {
             // make sure all system users are created first
             CreateServiceUser operation = new CreateServiceUser(systemUser.getId(), new WithPathOptions(calculateIntermediatePath(systemUser), enforcePrincipalBased(systemUser)));
             formatter.format("%s", operation.asRepoInitString());
+            if (systemUser.getDisabledReason() != null) {
+                DisableServiceUser disable = new DisableServiceUser(systemUser.getId(), systemUser.getDisabledReason());
+                formatter.format("%s", disable.asRepoInitString());
+            }
 
             if (aclIsBelow(systemUser.getPath())) {
                 throw new IllegalStateException("Detected policy on subpath of system-user: " + systemUser);

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/SystemUser.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/SystemUser.java
@@ -18,6 +18,7 @@ package org.apache.sling.feature.cpconverter.accesscontrol;
 
 import org.apache.sling.feature.cpconverter.shared.RepoPath;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SystemUser extends AbstractUser {
 
@@ -28,5 +29,15 @@ public class SystemUser extends AbstractUser {
      */
     public SystemUser(@NotNull String id, @NotNull RepoPath path, @NotNull RepoPath intermediatePath) {
         super(id, path, intermediatePath);
+    }
+
+    /**
+     * @param id - the authorizableId to use.
+     * @param path - the original repository path of the user in the content-package.
+     * @param intermediatePath - the intermediate path the user should have - most likely the (direct) parent of the path.
+     * @param disabledReason - the reason why this user has been disabled or {@code null}.
+     */
+    public SystemUser(@NotNull String id, @NotNull RepoPath path, @NotNull RepoPath intermediatePath, @Nullable String disabledReason) {
+        super(id, path, intermediatePath, disabledReason);
     }
 }

--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/User.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/User.java
@@ -18,6 +18,7 @@ package org.apache.sling.feature.cpconverter.accesscontrol;
 
 import org.apache.sling.feature.cpconverter.shared.RepoPath;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class User extends AbstractUser {
 
@@ -28,5 +29,15 @@ public class User extends AbstractUser {
      */
     public User(@NotNull String id, @NotNull RepoPath path, @NotNull RepoPath intermediatePath) {
         super(id, path, intermediatePath);
+    }
+
+    /**
+     * @param id               - the authorizableId to use.
+     * @param path             - the original repository path of the user in the content-package.
+     * @param intermediatePath - the intermediate path the user should have - most likely the (direct) parent of the path.
+     * @param disabledReason   - the reason why this user has been disabled or {@code null}.
+     */
+    public User(@NotNull String id, @NotNull RepoPath path, @NotNull RepoPath intermediatePath, @Nullable String disabledReason) {
+        super(id, path, intermediatePath, disabledReason);
     }
 }

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/AbstractUserParser.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/AbstractUserParser.java
@@ -49,7 +49,7 @@ abstract class AbstractUserParser extends AbstractJcrNodeParser<Void> {
     protected void onJcrRootElement(String uri, String localName, String qName, Attributes attributes) {
         String authorizableId = attributes.getValue(REP_AUTHORIZABLE_ID);
         if (authorizableId != null && !authorizableId.isEmpty()) {
-            handleUser(authorizableId);
+            handleUser(authorizableId, attributes);
         }
     }
 
@@ -58,6 +58,6 @@ abstract class AbstractUserParser extends AbstractJcrNodeParser<Void> {
         return null;
     }
 
-    abstract void handleUser(@NotNull String id);
+    abstract void handleUser(@NotNull String id, @NotNull Attributes attributes);
 
 }

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/GroupEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/GroupEntryHandler.java
@@ -20,6 +20,7 @@ import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter
 import org.apache.sling.feature.cpconverter.accesscontrol.Group;
 import org.apache.sling.feature.cpconverter.shared.RepoPath;
 import org.jetbrains.annotations.NotNull;
+import org.xml.sax.Attributes;
 
 public final class GroupEntryHandler extends AbstractUserEntryHandler {
 
@@ -55,7 +56,7 @@ public final class GroupEntryHandler extends AbstractUserEntryHandler {
         }
 
         @Override
-        void handleUser(@NotNull String id) {
+        void handleUser(@NotNull String id, @NotNull Attributes attributes) {
             converter.getAclManager().addGroup(new Group(id, path, intermediatePath));
         }
     }

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/UsersEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/UsersEntryHandler.java
@@ -21,6 +21,7 @@ import org.apache.sling.feature.cpconverter.accesscontrol.SystemUser;
 import org.apache.sling.feature.cpconverter.accesscontrol.User;
 import org.apache.sling.feature.cpconverter.shared.RepoPath;
 import org.jetbrains.annotations.NotNull;
+import org.xml.sax.Attributes;
 
 public final class UsersEntryHandler extends AbstractUserEntryHandler {
 
@@ -39,10 +40,10 @@ public final class UsersEntryHandler extends AbstractUserEntryHandler {
 
     @Override
     AbstractUserParser createParser(@NotNull ContentPackage2FeatureModelConverter converter, @NotNull RepoPath originalPath, @NotNull RepoPath intermediatePath) {
-        return new SystemUserParser(converter, originalPath, intermediatePath);
+        return new UserParser(converter, originalPath, intermediatePath);
     }
 
-    private static final class SystemUserParser extends AbstractUserParser {
+    private static final class UserParser extends AbstractUserParser {
 
         private static final String REP_SYSTEM_USER = "rep:SystemUser";
         private static final String REP_USER = "rep:User";
@@ -52,16 +53,17 @@ public final class UsersEntryHandler extends AbstractUserEntryHandler {
          * @param path - the original repository path of the user in the content-package.
          * @param intermediatePath - the intermediate path the user should have - most likely the (direct) parent of the path.
          */
-        public SystemUserParser(@NotNull ContentPackage2FeatureModelConverter converter, @NotNull RepoPath path, @NotNull RepoPath intermediatePath) {
+        public UserParser(@NotNull ContentPackage2FeatureModelConverter converter, @NotNull RepoPath path, @NotNull RepoPath intermediatePath) {
             super(converter, path, intermediatePath, REP_SYSTEM_USER, REP_USER);
         }
 
         @Override
-        void handleUser(@NotNull String id) {
+        void handleUser(@NotNull String id, @NotNull Attributes attributes) {
+            String disabledReason = attributes.getValue("rep:disabled");
             if (REP_USER.equals(detectedPrimaryType)) {
-                converter.getAclManager().addUser(new User(id, path, intermediatePath));
-            } else{
-                converter.getAclManager().addSystemUser(new SystemUser(id, path, intermediatePath));
+                converter.getAclManager().addUser(new User(id, path, intermediatePath, disabledReason));
+            } else {
+                converter.getAclManager().addSystemUser(new SystemUser(id, path, intermediatePath, disabledReason));
             }
         }
     }

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/home/users/a/disableduser/.content.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/home/users/a/disableduser/.content.xml
@@ -16,8 +16,9 @@
  the License.
 -->
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
-          jcr:primaryType="rep:SystemUser"
-          jcr:uuid="0a39b2bb-8594-3d80-a4fe-3464cfb7038b"
-          rep:authorizableId="service1"
-          rep:principalName="service1"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="rep:User"
+          jcr:uuid="098f6bcd-4621-3373-8ade-4e832627b4f6"
+          rep:authorizableId="test"
+          rep:principalName="test" 
           rep:disabled="a reason"/>


### PR DESCRIPTION
@karlpauls , i would appreciate if you had time to take a look at the suggested fix. nothing urgent and it's probably a minor bug but if the converter is expected to work reliably with an increasing number of different content packages that's something that sooner or later will pop up (and potentially cause security issues).