### PR TITLE
SLING-10386 : Converter needs to issue create path statements for repoinit path without node type

### DIFF
--- a/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/EnforcePrincipalBasedTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/EnforcePrincipalBasedTest.java
@@ -197,6 +197,7 @@ public class EnforcePrincipalBasedTest {
 
         String expected = normalize(
                 "create service user user1 with path " +relativeIntermediatePath+ "\n" +
+                "create path /content/feature\n" +        
                 "set ACL for user1\n" +
                 "    allow jcr:read on /content/feature\n" +
                 "end\n");
@@ -239,6 +240,7 @@ public class EnforcePrincipalBasedTest {
 
         String expected = normalize(
                 "create service user user1 with path " + relativeIntermediatePath + "\n" +
+                        "create path /content/feature\n" +
                         "set ACL for user1\n" +
                         "    allow jcr:read on /content/feature\n" +
                         "end\n");

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/RepPolicyEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/RepPolicyEntryHandlerTest.java
@@ -265,6 +265,7 @@ public final class RepPolicyEntryHandlerTest {
         Extension repoinitExtension = parseAndSetRepoinit(path, aclManager).getRepoinitExtension();
         String expected = normalize(
                 "create service user service1 with path system/services\n" +
+                "create path /asd/jr2restrictions\n" +
                 "set ACL for service1\n" +
                 "    allow jcr:read on /asd/jr2restrictions restriction(rep:glob,*/subtree/*) restriction(sling:customRestriction,sling:value1,sling:value2)\n" +
                 "end\n");


### PR DESCRIPTION
@karlpauls , as discussed a proposed fix. note, that no attempt is made to create a path below /home if the type information is missing altogether. the reason for this is the nodetype definition of rep:AuthorizableFolder, which would pick rep:User as the default primary type first (and not rep:AuthorizableFolder) and thus would likely result in a failure during repo-init