### PR TITLE
SLING-10388 : RepoPath.getParent returns null for top-level paths

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/DefaultAclManager.java
@@ -415,7 +415,7 @@ public class DefaultAclManager implements AclManager, EnforceInfo {
         boolean foundType = false;
 
         CreatePath cp = new CreatePath(null);
-        for (String part : path.toString().substring(1).split("/")) {
+        for (String part : path.getSegments()) {
             String platformname = PlatformNameFormat.getPlatformName(part);
             platformPath += platformPath.isEmpty() ? platformname : "/" + platformname;
             boolean segmentAdded = false;

--- a/src/main/java/org/apache/sling/feature/cpconverter/shared/RepoPath.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/shared/RepoPath.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -50,7 +51,7 @@ public class RepoPath implements Comparable<RepoPath>{
         if (path.startsWith("/"))
             path = path.substring(1);
 
-        this.path = Arrays.asList(path.split("/"));
+        this.path = (path.isEmpty()) ? Collections.emptyList() : Arrays.asList(path.split("/"));
     }
 
     /**
@@ -78,23 +79,16 @@ public class RepoPath implements Comparable<RepoPath>{
      * further parent.
      */
     public @Nullable RepoPath getParent() {
+        // root path or repository path
         if (path.isEmpty())
             return null;
 
         ArrayList<String> parentPath = new ArrayList<>(path.subList(0, path.size() - 1));
-        if (parentPath.isEmpty())
-            return null;
-
         return new RepoPath(parentPath);
     }
-
-    /**
-     * Get the nubmer of segments in this path.
-     *
-     * @return The number of segments.
-     */
-    public int getSegmentCount() {
-        return path.size();
+    
+    public List<String> getSegments() {
+        return path;
     }
 
     /**
@@ -104,11 +98,13 @@ public class RepoPath implements Comparable<RepoPath>{
      * @return If it starts with the other path or not.
      */
     public boolean startsWith(RepoPath otherPath) {
-        if (otherPath == null)
-            return true; // Every path starts with the root path
-
-        if (path.size() < otherPath.path.size())
+        if (otherPath == null || isRepositoryPath || otherPath.isRepositoryPath) {
             return false;
+        }
+
+        if (path.size() < otherPath.path.size()) {
+            return false;
+        }
 
         List<String> l = new ArrayList<>(path.subList(0, otherPath.path.size()));
         return l.equals(otherPath.path);
@@ -120,7 +116,7 @@ public class RepoPath implements Comparable<RepoPath>{
 
     @Override
     public int hashCode() {
-        return Objects.hash(path);
+        return Objects.hash(path, isRepositoryPath);
     }
 
     @Override
@@ -132,11 +128,11 @@ public class RepoPath implements Comparable<RepoPath>{
         if (getClass() != obj.getClass())
             return false;
         RepoPath other = (RepoPath) obj;
-        return Objects.equals(path, other.path);
+        return Objects.equals(path, other.path) && isRepositoryPath == other.isRepositoryPath;
     }
 
     @Override
     public String toString() {
-        return "/" + path.stream().collect(Collectors.joining("/"));
+        return isRepositoryPath ? "" : "/" + path.stream().collect(Collectors.joining("/"));
     }
 }

--- a/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/AclManagerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/accesscontrol/AclManagerTest.java
@@ -398,6 +398,14 @@ public class AclManagerTest {
     }
 
     @Test
+    public void testGetCreatePathForToplevel() {
+        RepoPath toplevel = new RepoPath("/apps");
+        DefaultAclManager aclManager = new DefaultAclManager();
+        CreatePath cp = aclManager.getCreatePath(toplevel, Collections.emptyList());
+        assertNotNull(cp);
+    }
+
+    @Test
     public void testGetCreatePathForPathBelowUserRoot() {
         RepoPath userPath = new RepoPath("/home/user/system/feature/usernode");
         DefaultAclManager aclManager = new DefaultAclManager();

--- a/src/test/java/org/apache/sling/feature/cpconverter/shared/RepoPathTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/shared/RepoPathTest.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -52,30 +54,85 @@ public class RepoPathTest {
     public void testGetParent() {
         RepoPath r1 = new RepoPath("/foo/bar");
         RepoPath r2 = new RepoPath("foo");
+        RepoPath r3 = new RepoPath("/foo");
 
         assertEquals(r2, r1.getParent());
-
-        assertNull(r2.getParent());
-        assertNull(new RepoPath(Collections.emptyList()).getParent());
-    }
-
-    @Test
-    public void testGetSegmentCount() {
-        assertEquals(2, new RepoPath("/foo/bar").getSegmentCount());
+        assertEquals(r3, r1.getParent());
     }
 
     @Test
     public void testStartsWith() {
         RepoPath r1 = new RepoPath("/foo/bar");
         RepoPath r2 = new RepoPath("foo");
+        RepoPath r3 = new RepoPath("/foo");
 
         assertTrue(r1.startsWith(r2));
+        assertTrue(r1.startsWith(r3));
         assertFalse(r2.startsWith(r1));
         assertTrue(r1.startsWith(r1));
         assertTrue(r2.startsWith(r2));
+        assertTrue(r2.startsWith(r3));
         assertFalse(r2.startsWith(new RepoPath(Collections.singletonList("fo"))));
 
         assertTrue(r1.startsWith(r1.getParent()));
         assertTrue(r2.startsWith(r2.getParent()));
+        assertTrue(r3.startsWith(r3.getParent()));
+    }
+
+    @Test
+    public void testTopLevelPath() {
+        RepoPath path = new RepoPath("/foo");
+        assertEquals("/foo", path.toString());
+        assertFalse(path.isRepositoryPath());
+
+        RepoPath parent = path.getParent();
+        assertNotNull(parent);
+        assertFalse(parent.isRepositoryPath());
+        assertEquals(new RepoPath("/"), parent);
+        
+        assertTrue(path.startsWith(path));
+        assertTrue(path.startsWith(new RepoPath("/")));
+        assertFalse(path.startsWith(new RepoPath("")));
+
+        assertEquals(new RepoPath("/foo"), path);
+        assertEquals(new RepoPath("foo"), path);
+        assertEquals(new RepoPath(Collections.singletonList("foo")), path);
+        
+        assertNotEquals(new RepoPath("/bar"), path);
+        assertNotEquals(new RepoPath("/"), path);
+        assertNotEquals(new RepoPath(""), path);
+    }
+    
+    @Test
+    public void testRootPath() {
+        RepoPath path = new RepoPath("/");
+        assertEquals("/", path.toString());
+        assertFalse(path.isRepositoryPath());
+
+        assertNull(path.getParent());
+
+        assertTrue(path.startsWith(path));
+        assertFalse(path.startsWith(new RepoPath("")));
+        assertFalse(path.startsWith(new RepoPath("/foo")));
+        
+        assertEquals(new RepoPath(Collections.emptyList()), path);
+        assertEquals(new RepoPath("/"), path);
+        assertNotEquals(new RepoPath(""), path);
+    }
+
+    @Test
+    public void testRepositoryPath() {
+        RepoPath path = new RepoPath("");
+        assertEquals("", path.toString());
+        assertTrue(path.isRepositoryPath());
+
+        assertNull(path.getParent());
+
+        assertFalse(path.startsWith(path));
+        assertFalse(path.startsWith(new RepoPath("/")));
+        assertFalse(path.startsWith(new RepoPath("/foo")));
+
+        assertEquals(new RepoPath(""), path);
+        assertNotEquals(new RepoPath(Collections.emptyList()), path);
     }
 }


### PR DESCRIPTION
@karlpauls , sorry.... didn't notice that you merged the previous commit already... wanted to keep the 2 bugs together as SLING-10386 cannot be fixed IMHO without fixing the RepoPath.