### PR TITLE
SLING-10769 : VaultPackageAssembler should not implement EntryHandler

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
@@ -52,6 +52,7 @@ import org.apache.sling.feature.cpconverter.artifacts.ArtifactsDeployer;
 import org.apache.sling.feature.cpconverter.artifacts.FileArtifactWriter;
 import org.apache.sling.feature.cpconverter.features.FeaturesManager;
 import org.apache.sling.feature.cpconverter.filtering.ResourceFilter;
+import org.apache.sling.feature.cpconverter.handlers.DefaultHandler;
 import org.apache.sling.feature.cpconverter.handlers.EntryHandler;
 import org.apache.sling.feature.cpconverter.handlers.EntryHandlersManager;
 import org.apache.sling.feature.cpconverter.handlers.NodeTypesEntryHandler;
@@ -476,7 +477,7 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
 
         EntryHandler entryHandler = handlersManager.getEntryHandlerByEntryPath(entryPath);
         if (entryHandler == null) {
-            entryHandler = getMainPackageAssembler();
+            entryHandler = new DefaultHandler(getMainPackageAssembler(), removeInstallHooks);
         }
 
         if (entry == null) {

--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/DefaultHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/DefaultHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.feature.cpconverter.handlers;
+
+import org.apache.jackrabbit.vault.fs.io.Archive;
+import org.apache.jackrabbit.vault.util.Constants;
+import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter;
+import org.apache.sling.feature.cpconverter.vltpkg.VaultPackageAssembler;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DefaultHandler implements EntryHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultHandler.class);
+    
+    private static final String INSTALL_HOOK_ROOT = "/" + Constants.META_DIR + "/" + Constants.HOOKS_DIR;
+
+    private final VaultPackageAssembler mainPackageAssembler;
+    private final boolean removeInstallHooks;
+    
+    public DefaultHandler(@NotNull VaultPackageAssembler mainPackageAssembler, boolean removeInstallHooks) {
+        this.mainPackageAssembler = mainPackageAssembler;
+        this.removeInstallHooks = removeInstallHooks;
+    }
+    
+    @Override
+    public boolean matches(@NotNull String path) {
+        return true;
+    }
+
+    @Override
+    public void handle(@NotNull String path, @NotNull Archive archive, @NotNull Archive.Entry entry, @NotNull ContentPackage2FeatureModelConverter converter)
+            throws IOException {
+        if (removeInstallHooks && path.startsWith(INSTALL_HOOK_ROOT)) {
+            log.info("Skipping install hook {} from original package", path);
+        } else {
+            mainPackageAssembler.addEntry(path, archive, entry);
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/DefaultHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/DefaultHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.feature.cpconverter.handlers;
+
+import org.apache.jackrabbit.vault.fs.io.Archive;
+import org.apache.jackrabbit.vault.util.Constants;
+import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter;
+import org.apache.sling.feature.cpconverter.vltpkg.VaultPackageAssembler;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+public class DefaultHandlerTest {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultHandlerTest.class);
+    
+    private final VaultPackageAssembler assembler = mock(VaultPackageAssembler.class);
+    
+    @Test
+    public void testMatch() {
+        DefaultHandler handler = new DefaultHandler(assembler, true);
+        assertTrue(handler.matches(""));
+        assertTrue(handler.matches("/"));
+        assertTrue(handler.matches("/jcr_root/.content.xml"));
+        assertTrue(handler.matches("/jcr_root/content"));
+        assertTrue(handler.matches("/jcr_root/apps"));
+        assertTrue(handler.matches("/jcr_root/content/_rep_policy.xml"));
+
+        verifyNoInteractions(assembler);
+    }
+    
+    @Test
+    public void testHandleInstallHooksTrue() throws Exception {
+        Archive archive = mock(Archive.class);
+        Archive.Entry entry = mock(Archive.Entry.class);
+        ContentPackage2FeatureModelConverter converter = mock(ContentPackage2FeatureModelConverter.class);
+
+        DefaultHandler handler = new DefaultHandler(assembler, true);
+        handler.handle("/" + Constants.META_DIR + "/" + Constants.HOOKS_DIR, archive, entry, converter);
+        
+        verifyNoInteractions(assembler, archive, entry, converter);
+    }
+
+    @Test
+    public void testHandleInstallHooksFalse() throws Exception {
+        Archive archive = mock(Archive.class);
+        Archive.Entry entry = mock(Archive.Entry.class);
+        ContentPackage2FeatureModelConverter converter = mock(ContentPackage2FeatureModelConverter.class);
+        String path = "/" + Constants.META_DIR + "/" + Constants.HOOKS_DIR + "/subdir";
+
+        DefaultHandler handler = new DefaultHandler(assembler, false);
+        handler.handle(path, archive, entry, converter);
+
+        verifyNoInteractions(archive, entry, converter);
+        verify(assembler).addEntry(path, archive, entry);
+    }
+
+    @Test
+    public void testHandleRegularPath() throws Exception {
+        Archive archive = mock(Archive.class);
+        Archive.Entry entry = mock(Archive.Entry.class);
+        ContentPackage2FeatureModelConverter converter = mock(ContentPackage2FeatureModelConverter.class);
+        String path = "/" + Constants.ROOT_DIR + "/content" + Constants.DOT_CONTENT_XML;
+
+        DefaultHandler handler = new DefaultHandler(assembler, true);
+        handler.handle(path, archive, entry, converter);
+
+        verifyNoInteractions(archive, entry, converter);
+        verify(assembler).addEntry(path, archive, entry);
+    }
+}

--- a/src/test/java/org/apache/sling/feature/cpconverter/vltpkg/VaultPackageAssemblerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/vltpkg/VaultPackageAssemblerTest.java
@@ -75,11 +75,6 @@ public class VaultPackageAssemblerTest {
     }
     
     @Test
-    public void matchAll() {
-        assembler.matches(resourceLocation);
-    }
-
-    @Test
     public void packageResource() throws Exception {
         if (resourceLocation != null) {
             assembler.addEntry(resourceLocation, getClass().getResourceAsStream("../handlers" + resourceLocation));


### PR DESCRIPTION
@karlpauls , let me know if you think that is rather unnecessary or confusing. to me VaultPackageAssembler implementing EntryHandler looks odd.... but it might just be me.