### PR TITLE
SLING-10783 : XmlConfigurationEntryHandler - sonar findings

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/XmlConfigurationEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/XmlConfigurationEntryHandler.java
@@ -69,7 +69,7 @@ public final class XmlConfigurationEntryHandler extends AbstractConfigurationEnt
                 // ignore jcr: and similar properties
                 if (attributeQName.indexOf(':') == -1) {
                     String attributeValue = attributes.getValue(i);
-                    if (!isEmptyOrNull(attributeValue)) {
+                    if (isValid(attributeValue)) {
                         DocViewProperty property = DocViewProperty.parse(attributeQName, attributeValue);
                         Object[] values = getValues(property);
                         if (values.length == 0) {
@@ -88,8 +88,8 @@ public final class XmlConfigurationEntryHandler extends AbstractConfigurationEnt
             }
         }
         
-        private static boolean isEmptyOrNull(@Nullable String s) {
-            return s == null || s.isEmpty();
+        private static boolean isValid(@Nullable String s) {
+            return !(s == null || s.isEmpty());
         }
         
         @NotNull 
@@ -121,13 +121,7 @@ public final class XmlConfigurationEntryHandler extends AbstractConfigurationEnt
         
         @NotNull 
         private static Object[] mapValues(@NotNull String[] strValues, Function<String, Object> function) {
-            return Arrays.stream(strValues).map(s -> {
-                Object res = null;
-                if (!isEmptyOrNull(s)) {
-                    res = function.apply(s);
-                }
-                return res;
-            }).filter(Objects::nonNull).toArray();
+            return Arrays.stream(strValues).filter(JcrConfigurationParser::isValid).map(function).filter(Objects::nonNull).toArray();
         }
 
         @Override


### PR DESCRIPTION
hi @karlpauls improving XmlConfigurationEntryHandler required a bit of refactoring. i would appreciate if you could take a look.
note: originally the switch-case contained non-null checks for all property types but that got removed with SLING-10329 : Remove dependency to Plexus StringUtils, which left the different cases in an inconsistent state (at least i kept wondering why some are checking for null, some only checking for empty string). it tried to fix that as well.