### PR TITLE
SLING-10929 : Wrap the exceptions of onFile an provide a path to the output

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
@@ -499,9 +499,9 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
         try {
             process(entryPath, archive, entry);
         }catch (ConverterException ex){
-            throw new ConverterException("ConverterException occured on path " + entryPath, ex);
+            throw new ConverterException("ConverterException occured on path " + entryPath + " with message: " + ex.getMessage(), ex);
         }catch(IOException ex){
-            throw new IOException("IOException occured on path " + entryPath, ex);
+            throw new IOException("IOException occured on path " + entryPath + " with message: " + ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
@@ -498,9 +498,9 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
     protected void onFile(@NotNull String entryPath, @NotNull Archive archive, @NotNull Entry entry) throws IOException, ConverterException {
         try {
             process(entryPath, archive, entry);
-        }catch (ConverterException ex){
+        } catch (ConverterException ex) {
             throw new ConverterException("ConverterException occured on path " + entryPath + " with message: " + ex.getMessage(), ex);
-        }catch(IOException ex){
+        } catch (IOException ex) {
             throw new IOException("IOException occured on path " + entryPath + " with message: " + ex.getMessage(), ex);
         }
     }

--- a/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
@@ -496,7 +496,13 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
 
     @Override
     protected void onFile(@NotNull String entryPath, @NotNull Archive archive, @NotNull Entry entry) throws IOException, ConverterException {
-        process(entryPath, archive, entry);
+        try {
+            process(entryPath, archive, entry);
+        }catch (ConverterException ex){
+            throw new ConverterException("ConverterException occured on path " + entryPath, ex);
+        }catch(IOException ex){
+            throw new IOException("IOException occured on path " + entryPath, ex);
+        }
     }
 
     public static @NotNull ArtifactId toArtifactId(@NotNull PackageId packageId, @NotNull File file) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-10929

From : 

<img width="820" alt="Screenshot 2021-11-18 at 11 53 02" src="https://user-images.githubusercontent.com/26429828/142402162-4cc72ec1-91fd-43d7-b6dd-69d688c45755.png">

To:

<img width="1435" alt="Screenshot 2021-11-18 at 11 51 39" src="https://user-images.githubusercontent.com/26429828/142401995-81550fa4-1191-482a-b3db-305bbdf436ca.png">
:
