### PR TITLE
SLING-11240 - Content packages with invalid Long properties cause index definition extraction to fail

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriter.java
@@ -48,6 +48,17 @@ public class IndexDefinitionsJsonWriter {
 
     private static final Function<String, JsonValue> BLOB_MAPPER =  s -> Json.createValue(":blobid:" + Base64.encode(s));
 
+    private static final Function<String, JsonValue> SAFE_LONG_MAPPER = new Function<String, JsonValue>() {
+
+        @Override
+        public JsonValue apply(String t) {
+            if ( t.endsWith(".0") )
+                t = t.replace(".0", "");
+
+            return Json.createValue(Long.parseLong(t));
+        }
+    };
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final IndexDefinitions indexDefinitions;
@@ -91,7 +102,7 @@ public class IndexDefinitionsJsonWriter {
                     write(json, propertyName, property.getStringValues(), s -> Json.createValue("str:" + s ));
                     break;
                 case PropertyType.LONG:
-                    write(json, propertyName, property.getStringValues(), s -> Json.createValue(Long.parseLong(s) ));
+                    write(json, propertyName, property.getStringValues(), SAFE_LONG_MAPPER );
                     break;
                 case PropertyType.BOOLEAN:
                     write(json, propertyName, property.getStringValues(), s -> ( Boolean.parseBoolean(s) ? JsonValue.TRUE : JsonValue.FALSE)  );

--- a/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
@@ -106,6 +106,27 @@ public class IndexDefinitionsJsonWriterTest {
     }
 
     @Test
+    public void invalidLongPropertyIsAccepted() throws IOException {
+
+        Collection<DocViewProperty2> fooProps = new ArrayList<>();
+        fooProps.add(new DocViewProperty2(nameFactory.create("{}type"), "property"));
+        fooProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), PREFIX_OAK+":QueryIndexDefinition"));
+        fooProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.FALSE.toString(), PropertyType.BOOLEAN));
+        fooProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "1.0", PropertyType.LONG));
+
+        definitions.addNode("/oak:index", new DocViewNode2(nameFactory.create("{}foo"), fooProps));
+
+        JsonObject root = generateAndParse(definitions);
+        assertThat(root).as("indexDefinitions")
+            .hasSize(1)
+            .hasEntrySatisfying("/oak:index/foo", Conditions.isJsonObject());
+
+        JsonObject fooIndex = root.getJsonObject("/oak:index/foo");
+        assertThat(fooIndex).as("foo index")
+            .contains(entry("reindexCount", Json.createValue(1)));
+    }
+
+    @Test
     public void luceneIndexDefinitionWithTikaConfig() throws IOException {
 
         String configXmlFileContents = "<properties/>";

--- a/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
@@ -83,10 +83,10 @@ public class IndexDefinitionsJsonWriterTest {
         definitions.addNode("/oak:index", new DocViewNode2(nameFactory.create("{}foo"), fooProps));
 
         Collection<DocViewProperty2> barProps = new ArrayList<>();
-        fooProps.add(new DocViewProperty2(nameFactory.create("{}type"), "property"));
-        fooProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), PREFIX_OAK+":QueryIndexDefinition"));
-        fooProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.TRUE.toString(), PropertyType.BOOLEAN));
-        fooProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "25", PropertyType.LONG));
+        barProps.add(new DocViewProperty2(nameFactory.create("{}type"), "property"));
+        barProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), PREFIX_OAK+":QueryIndexDefinition"));
+        barProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.TRUE.toString(), PropertyType.BOOLEAN));
+        barProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "25", PropertyType.LONG));
 
         definitions.addNode("/oak:index", new DocViewNode2(nameFactory.create("{}bar"), barProps));
 


### PR DESCRIPTION
Tolerate long values that end with '.0', the intent is clearly for them to be valid longs.