### PR TITLE
SLING-11241 - Content package with index definitions missing the Oak namespace causes index extraction to fail

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandler.java
@@ -35,6 +35,7 @@ import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter
 import org.apache.sling.feature.cpconverter.ConverterException;
 import org.apache.sling.feature.cpconverter.index.IndexDefinitions;
 import org.apache.sling.feature.cpconverter.index.IndexManager;
+import org.apache.sling.feature.cpconverter.index.SimpleNamespaceResolver;
 import org.jetbrains.annotations.NotNull;
 import org.xml.sax.InputSource;
 
@@ -112,7 +113,7 @@ public class IndexDefinitionsEntryHandler extends AbstractRegexEntryHandler {
                     isDocView =  DocViewParser.isDocView(new InputSource(isCheck));
                 }
                 if ( isDocView ) {
-                    DocViewParser parser = new DocViewParser();
+                    DocViewParser parser = new DocViewParser(new SimpleNamespaceResolver());
                     IndexDefinitionsParserHandler handler = new IndexDefinitionsParserHandler(archive.getMetaInf().getFilter(), indexManager.getIndexes());
 
                     parser.parse(repositoryPath, inputSource, handler);

--- a/src/main/java/org/apache/sling/feature/cpconverter/index/SimpleNamespaceResolver.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/index/SimpleNamespaceResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.cpconverter.index;
+
+import javax.jcr.NamespaceException;
+
+import org.apache.jackrabbit.spi.commons.namespace.NamespaceResolver;
+
+/**
+ * A simple resolver that is aware of the default {@value #OAK_PREFIX} prefix and namespace
+ */
+public class SimpleNamespaceResolver implements NamespaceResolver {
+
+    // copied from oak-spi-core/NamespaceConstants to not add a dependency on Oak
+    static final String OAK_PREFIX = "oak";
+    static final String OAK_NAMESPACE = "http://jackrabbit.apache.org/oak/ns/1.0";
+
+    @Override
+    public String getURI(String prefix) throws NamespaceException {
+        if ( OAK_PREFIX.equals(prefix) )
+            return OAK_NAMESPACE;
+        return null;
+    }
+
+    @Override
+    public String getPrefix(String uri) throws NamespaceException {
+        if (OAK_NAMESPACE.equals(uri) )
+            return OAK_PREFIX;
+
+        return null;
+    }
+}

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandlerTest.java
@@ -189,6 +189,13 @@ public class IndexDefinitionsEntryHandlerTest {
 
     }
 
+    @Test
+    public void handleIndexDefinitionWithMissingNamespaces() throws IOException, ConverterException {
+        DefaultIndexManager manager = new DefaultIndexManager();
+
+        traverseForIndexing(manager, "index_missing_namespaces");
+    }
+
     private void assertIsValidXml(byte[] tikeConfig) throws ParserConfigurationException, SAXException, IOException {
 
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.sling.feature.cpconverter.index;
 
+import static org.apache.sling.feature.cpconverter.index.SimpleNamespaceResolver.OAK_NAMESPACE;
+import static org.apache.sling.feature.cpconverter.index.SimpleNamespaceResolver.OAK_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -48,10 +50,6 @@ import org.junit.Test;
 
 public class IndexDefinitionsJsonWriterTest {
 
-    // copied from oak-spi-core/NamespaceConstants to not add a dependency on Oak
-    private static final String PREFIX_OAK = "oak";
-    private static final String NAMESPACE_OAK = "http://jackrabbit.apache.org/oak/ns/1.0";
-
     private NameFactory nameFactory;
     private IndexDefinitions definitions;
 
@@ -61,7 +59,7 @@ public class IndexDefinitionsJsonWriterTest {
         definitions = new IndexDefinitions();
         definitions.registerPrefixMapping(NamespaceRegistry.PREFIX_NT, NamespaceRegistry.NAMESPACE_NT);
         definitions.registerPrefixMapping(NamespaceRegistry.PREFIX_JCR, NamespaceRegistry.NAMESPACE_JCR);
-        definitions.registerPrefixMapping(PREFIX_OAK, NAMESPACE_OAK);
+        definitions.registerPrefixMapping(OAK_PREFIX, OAK_NAMESPACE);
 
     }
 
@@ -76,7 +74,7 @@ public class IndexDefinitionsJsonWriterTest {
 
         Collection<DocViewProperty2> fooProps = new ArrayList<>();
         fooProps.add(new DocViewProperty2(nameFactory.create("{}type"), "property"));
-        fooProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), PREFIX_OAK+":QueryIndexDefinition"));
+        fooProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), OAK_PREFIX+":QueryIndexDefinition"));
         fooProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.FALSE.toString(), PropertyType.BOOLEAN));
         fooProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "1", PropertyType.LONG));
 
@@ -84,7 +82,7 @@ public class IndexDefinitionsJsonWriterTest {
 
         Collection<DocViewProperty2> barProps = new ArrayList<>();
         barProps.add(new DocViewProperty2(nameFactory.create("{}type"), "property"));
-        barProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), PREFIX_OAK+":QueryIndexDefinition"));
+        barProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), OAK_PREFIX+":QueryIndexDefinition"));
         barProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.TRUE.toString(), PropertyType.BOOLEAN));
         barProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "25", PropertyType.LONG));
 
@@ -110,7 +108,7 @@ public class IndexDefinitionsJsonWriterTest {
 
         Collection<DocViewProperty2> fooProps = new ArrayList<>();
         fooProps.add(new DocViewProperty2(nameFactory.create("{}type"), "property"));
-        fooProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), PREFIX_OAK+":QueryIndexDefinition"));
+        fooProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), OAK_PREFIX+":QueryIndexDefinition"));
         fooProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.FALSE.toString(), PropertyType.BOOLEAN));
         fooProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "1.0", PropertyType.LONG));
 
@@ -134,7 +132,7 @@ public class IndexDefinitionsJsonWriterTest {
         // lucene index
         Collection<DocViewProperty2> luceneProps = new ArrayList<>();
         luceneProps.add(new DocViewProperty2(nameFactory.create("{}type"), "lucene"));
-        luceneProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), PREFIX_OAK+":QueryIndexDefinition"));
+        luceneProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), OAK_PREFIX+":QueryIndexDefinition"));
         luceneProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.FALSE.toString(), PropertyType.BOOLEAN));
         luceneProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "1", PropertyType.LONG));
         luceneProps.add(new DocViewProperty2(nameFactory.create("{}includePropertyTypes"), Arrays.asList("String", "Binary"), PropertyType.STRING));

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/META-INF/vault/filter.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<workspaceFilter version="1.0">
+    <filter root="/oak:index/foo"/>
+</workspaceFilter>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/META-INF/vault/nodetypes.cnd
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/META-INF/vault/nodetypes.cnd
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+<'sling'='http://sling.apache.org/jcr/sling/1.0'>
+<'nt'='http://www.jcp.org/jcr/nt/1.0'>
+
+[sling:Folder] > nt:folder
+  - * (undefined)
+  - * (undefined) multiple
+  + * (nt:base) = sling:Folder version
+

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/META-INF/vault/properties.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/META-INF/vault/properties.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>FileVault Package Properties</comment>
+<entry key="createdBy">admin</entry>
+<entry key="name">index_single_file</entry>
+<entry key="lastModified">2011-11-15T09:45:14.664+01:00</entry>
+<entry key="lastModifiedBy">admin</entry>
+<entry key="created">2011-11-15T09:45:14.685+01:00</entry>
+<entry key="buildCount">1</entry>
+<entry key="version"/>
+<entry key="dependencies"/>
+<entry key="packageFormatVersion">2</entry>
+<entry key="description"/>
+<entry key="lastWrapped">2011-11-15T09:45:14.664+01:00</entry>
+<entry key="group"/>
+<entry key="lastWrappedBy">admin</entry>
+</properties>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/jcr_root/.content.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/jcr_root/.content.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:root"
+    sling:resourceType="sling:redirect"
+    sling:target="/index.html">
+    <rep:policy/>
+    <jcr:system/>
+    <var/>
+    <libs/>
+    <etc/>
+    <apps/>
+    <content/>
+    <tmp/>
+    <home/>
+</jcr:root>

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/jcr_root/_oak_index/.content.xml
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/index/index_missing_namespaces/jcr_root/_oak_index/.content.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="nt:unstructured">
+    <foo
+        jcr:primaryType="oak:QueryIndexDefinition"
+        propertyNames="[foo]"
+        reindex="{Boolean}false"
+        reindexCount="{Long}1"
+        type="property">
+    </foo>
+</jcr:root>


### PR DESCRIPTION
Introduce a NamespaceResolver that is aware of the default Oak namespace URI and prefix.