### PR TITLE
SKYOPS-25075 - Synthesized namespace extraction (from new extension)

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/features/DefaultFeaturesManager.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/features/DefaultFeaturesManager.java
@@ -275,6 +275,10 @@ public class DefaultFeaturesManager implements FeaturesManager, PackagesEventsEm
             getAclManager().addRepoinitExtention("seed", repoInitText, "seed", this);
             extractNamespaces(repoInitText, namespaceUriByPrefix);
         }
+        if (seed.getExtensions().getByName("extracted-repo-namespaces") != null) {
+            String repoInitText = seed.getExtensions().getByName("extracted-repo-namespaces").getText();
+            extractNamespaces(repoInitText, namespaceUriByPrefix);
+        }
 
     }
 


### PR DESCRIPTION
Add extension  extracted-repo-namespaces to extract namespaces from a synthesized / lightweight repoinit