### PR TITLE
SLING-11675 - Index definition extraction from content packages is missing non-XML files

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandler.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandler.java
@@ -48,12 +48,18 @@ import org.xml.sax.InputSource;
  */
 public class IndexDefinitionsEntryHandler extends AbstractRegexEntryHandler {
 
+    private static final String[] EXCLUDED_EXTENSIONS = new String[]{
+            "vlt",
+            "gitignore"
+    };
     private static final String PATH_PATTERN = "" +
-            "/jcr_root/" + // jcr_root dir
-            "(.*/)?" + // optional path segment
+            "/jcr_root" + // jcr_root dir
+            "(.*/?)/" + // optional path segment
             PlatformNameFormat.getPlatformName(IndexDefinitions.OAK_INDEX_NAME) +
-            "(.*/)?" + // additional path segments
-            "/.*xml"; // only xml files
+            "(.*/?)" + // additional path segments
+            "/(.*?)\\.(?!(" + //excluding extensions
+            String.join("|", EXCLUDED_EXTENSIONS) +
+            ")$)[^.]+$"; // match everything else
 
     private final class IndexDefinitionsParserHandler implements DocViewParserHandler {
         private final WorkspaceFilter filter;

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandlerTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/IndexDefinitionsEntryHandlerTest.java
@@ -55,9 +55,12 @@ public class IndexDefinitionsEntryHandlerTest {
         IndexDefinitionsEntryHandler handler = new IndexDefinitionsEntryHandler();
         assertThat(handler.matches("/jcr_root/_oak_index/.content.xml")).isTrue();
         assertThat(handler.matches("/jcr_root/not_oak_index/.content.xml")).isFalse();
+        assertThat(handler.matches("/jcr_root/not_oak_index/stop.txt")).isFalse();
         assertThat(handler.matches("/jcr_root/_oak_index/bar/.content.xml")).isTrue();
         assertThat(handler.matches("/jcr_root/_oak_index/lucene/tika/config.xml")).isTrue();
         assertThat(handler.matches("/jcr_root/_oak_index/.vlt")).isFalse();
+        assertThat(handler.matches("/jcr_root/_oak_index/stop.txt")).isTrue();
+        assertThat(handler.matches("/jcr_root/not_oak_index/.vlt")).isFalse();
         assertThat(handler.matches("/jcr_root/apps/_oak_index/.content.xml")).isTrue();
         assertThat(handler.matches("/jcr_root/apps/.content.xml")).isFalse();
         assertThat(handler.matches("/jcr_root/not_oak_index/.content.xml")).isFalse();


### PR DESCRIPTION
Change the indexdefinitionshandler to include everything under oak index, except for a blacklist of files