### PR TITLE
SLING-11837 - Align index definition generation logic with the one from Oak

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriter.java
@@ -52,6 +52,14 @@ import jakarta.json.stream.JsonGenerator;
  */
 public class IndexDefinitionsJsonWriter {
 
+    private static final Function<String, JsonValue> STRING_MAPPER =  s -> {
+        // don't generate unnecessary 'str:' prefixes, see https://github.com/apache/jackrabbit-oak/blob/838780a7aaf9775ad0bf7b6be65c1a1619e65eb7/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/json/JsonSerializer.java#L269-L291 
+        if ( s.length() > 3 && s.charAt(3) == ':' )
+            return Json.createValue("str:" + s );
+
+        return Json.createValue(s);
+    };
+
     private static final Function<String, JsonValue> BLOB_MAPPER =  s -> Json.createValue(":blobId:" + Base64.encode(s));
 
     private static final Function<String, JsonValue> SAFE_LONG_MAPPER = new Function<String, JsonValue>() {
@@ -105,7 +113,7 @@ public class IndexDefinitionsJsonWriter {
             switch ( property.getType() ) {
                 case PropertyType.STRING:
                 case PropertyType.UNDEFINED:
-                    write(json, propertyName, property.getStringValues(), s -> Json.createValue("str:" + s ));
+                    write(json, propertyName, property.getStringValues(), STRING_MAPPER);
                     break;
                 case PropertyType.LONG:
                     write(json, propertyName, property.getStringValues(), SAFE_LONG_MAPPER );

--- a/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/index/IndexDefinitionsJsonWriterTest.java
@@ -33,11 +33,6 @@ import java.util.List;
 
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.PropertyType;
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
-import jakarta.json.stream.JsonParser;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.spi.NameFactory;
@@ -48,6 +43,12 @@ import org.apache.jackrabbit.vault.util.DocViewProperty2;
 import org.assertj.core.api.Condition;
 import org.junit.Before;
 import org.junit.Test;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonParser;
 
 public class IndexDefinitionsJsonWriterTest {
 
@@ -75,6 +76,7 @@ public class IndexDefinitionsJsonWriterTest {
 
         Collection<DocViewProperty2> fooProps = new ArrayList<>();
         fooProps.add(new DocViewProperty2(nameFactory.create("{}type"), "property"));
+        fooProps.add(new DocViewProperty2(nameFactory.create("{}comment"), "foo:bar"));
         fooProps.add(new DocViewProperty2(nameFactory.create(NamespaceRegistry.NAMESPACE_JCR, "primaryType"), OAK_PREFIX+":QueryIndexDefinition"));
         fooProps.add(new DocViewProperty2(nameFactory.create("{}reindex"), Boolean.FALSE.toString(), PropertyType.BOOLEAN));
         fooProps.add(new DocViewProperty2(nameFactory.create("{}reindexCount"), "1", PropertyType.LONG));
@@ -97,8 +99,9 @@ public class IndexDefinitionsJsonWriterTest {
 
         JsonObject fooIndex = root.getJsonObject("/oak:index/foo");
         assertThat(fooIndex).as("foo index")
-            .hasSize(4)
-            .contains(entry("type", Json.createValue("str:property")))
+            .hasSize(5)
+            .contains(entry("type", Json.createValue("property")))
+            .contains(entry("comment", Json.createValue("str:foo:bar")))
             .contains(entry("jcr:primaryType", Json.createValue("nam:oak:QueryIndexDefinition")))
             .contains(entry("reindex", JsonObject.FALSE))
             .contains(entry("reindexCount", Json.createValue(1)));


### PR DESCRIPTION
Avoid setting the 'str:' prefix unless necessary.