### PR TITLE
SLING-11750 : Support the new repoinit statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.repoinit.parser</artifactId>
-      <version>1.7.0</version>
+      <version>1.9.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/sling/feature/cpconverter/repoinit/DefaultVisitor.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/repoinit/DefaultVisitor.java
@@ -17,6 +17,7 @@
 package org.apache.sling.feature.cpconverter.repoinit;
 
 import org.apache.sling.repoinit.parser.operations.AddGroupMembers;
+import org.apache.sling.repoinit.parser.operations.AddMixins;
 import org.apache.sling.repoinit.parser.operations.CreateGroup;
 import org.apache.sling.repoinit.parser.operations.CreatePath;
 import org.apache.sling.repoinit.parser.operations.CreateUser;
@@ -27,6 +28,8 @@ import org.apache.sling.repoinit.parser.operations.DeleteGroup;
 import org.apache.sling.repoinit.parser.operations.DeleteServiceUser;
 import org.apache.sling.repoinit.parser.operations.DeleteUser;
 import org.apache.sling.repoinit.parser.operations.DisableServiceUser;
+import org.apache.sling.repoinit.parser.operations.EnsureAclPrincipalBased;
+import org.apache.sling.repoinit.parser.operations.EnsureNodes;
 import org.apache.sling.repoinit.parser.operations.RegisterNamespace;
 import org.apache.sling.repoinit.parser.operations.RegisterNodetypes;
 import org.apache.sling.repoinit.parser.operations.RegisterPrivilege;
@@ -34,6 +37,7 @@ import org.apache.sling.repoinit.parser.operations.RemoveAcePaths;
 import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipalBased;
 import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipals;
 import org.apache.sling.repoinit.parser.operations.RemoveGroupMembers;
+import org.apache.sling.repoinit.parser.operations.RemoveMixins;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipalBased;
 import org.apache.sling.repoinit.parser.operations.SetProperties;
 import org.jetbrains.annotations.NotNull;
@@ -79,8 +83,18 @@ class DefaultVisitor extends NoOpVisitor {
     }
 
     @Override
+    public void visitEnsureAclPrincipalBased(EnsureAclPrincipalBased ensureAclPrincipalBased) {
+        formatter.format("%s", ensureAclPrincipalBased.asRepoInitString());
+    }
+
+    @Override
     public void visitCreatePath(CreatePath createPath) {
         formatter.format("%s", createPath.asRepoInitString());
+    }
+    
+    @Override
+    public void visitEnsureNodes(EnsureNodes en) {
+        formatter.format("%s", en.asRepoInitString());
     }
 
     @Override
@@ -130,6 +144,16 @@ class DefaultVisitor extends NoOpVisitor {
 
     @Override
     public void visitDeleteAclPrincipalBased(DeleteAclPrincipalBased s) {
+        formatter.format("%s", s.asRepoInitString());
+    }
+
+    @Override
+    public void visitAddMixins(AddMixins s) {
+        formatter.format("%s", s.asRepoInitString());
+    }
+
+    @Override
+    public void visitRemoveMixins(RemoveMixins s) {
         formatter.format("%s", s.asRepoInitString());
     }
 

--- a/src/main/java/org/apache/sling/feature/cpconverter/repoinit/NoOpVisitor.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/repoinit/NoOpVisitor.java
@@ -17,6 +17,7 @@
 package org.apache.sling.feature.cpconverter.repoinit;
 
 import org.apache.sling.repoinit.parser.operations.AddGroupMembers;
+import org.apache.sling.repoinit.parser.operations.AddMixins;
 import org.apache.sling.repoinit.parser.operations.CreateGroup;
 import org.apache.sling.repoinit.parser.operations.CreatePath;
 import org.apache.sling.repoinit.parser.operations.CreateServiceUser;
@@ -28,6 +29,8 @@ import org.apache.sling.repoinit.parser.operations.DeleteGroup;
 import org.apache.sling.repoinit.parser.operations.DeleteServiceUser;
 import org.apache.sling.repoinit.parser.operations.DeleteUser;
 import org.apache.sling.repoinit.parser.operations.DisableServiceUser;
+import org.apache.sling.repoinit.parser.operations.EnsureAclPrincipalBased;
+import org.apache.sling.repoinit.parser.operations.EnsureNodes;
 import org.apache.sling.repoinit.parser.operations.OperationVisitor;
 import org.apache.sling.repoinit.parser.operations.RegisterNamespace;
 import org.apache.sling.repoinit.parser.operations.RegisterNodetypes;
@@ -36,6 +39,7 @@ import org.apache.sling.repoinit.parser.operations.RemoveAcePaths;
 import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipalBased;
 import org.apache.sling.repoinit.parser.operations.RemoveAcePrincipals;
 import org.apache.sling.repoinit.parser.operations.RemoveGroupMembers;
+import org.apache.sling.repoinit.parser.operations.RemoveMixins;
 import org.apache.sling.repoinit.parser.operations.SetAclPaths;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipalBased;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipals;
@@ -80,6 +84,10 @@ public abstract class NoOpVisitor implements OperationVisitor {
     }
 
     @Override
+    public void visitEnsureAclPrincipalBased(EnsureAclPrincipalBased ensureAclPrincipalBased) {
+    }
+
+    @Override
     public void visitRemoveAcePrincipal(RemoveAcePrincipals s) {
     }
 
@@ -93,6 +101,10 @@ public abstract class NoOpVisitor implements OperationVisitor {
 
     @Override
     public void visitCreatePath(CreatePath createPath) {
+    }
+
+    @Override
+    public void visitEnsureNodes(EnsureNodes en) {
     }
 
     @Override
@@ -133,5 +145,13 @@ public abstract class NoOpVisitor implements OperationVisitor {
 
     @Override
     public void visitDeleteAclPrincipalBased(DeleteAclPrincipalBased s) {
+    }
+
+    @Override
+    public void visitAddMixins(AddMixins s) {
+    }
+
+    @Override
+    public void visitRemoveMixins(RemoveMixins s) {
     }
 }

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.publish/org.apache.sling.jcr.repoinit.RepositoryInitializer-no-conversion-result.config
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.publish/org.apache.sling.jcr.repoinit.RepositoryInitializer-no-conversion-result.config
@@ -65,6 +65,20 @@ delete group gr1",\
 "
 create path /test(sling:Folder)/a(nt:folder mixin mix:referenceable,mix:shareable)/b(nt:unstructured)/c(sling:Folder mixin mix:created)
 create path (sling:Folder) /test/a(nt:folder mixin mix:referenceable,mix:shareable)/b(nt:unstructured)/c( mixin mix:created)
+ensure nodes /three/four(nt:folk)/five(nt:jazz)/six
+ensure nodes (nt:x) /seven/eight/nine
+ensure nodes /one(mixin nt:art)/step(mixin nt:dance)/two/steps
+ensure nodes (nt:foxtrot) /one/step(mixin nt:dance)/two/steps
+ensure nodes /one/step(mixin nt:dance,nt:art)/two/steps
+ensure nodes /one/step(nt:foxtrot mixin nt:dance)/two/steps
+ensure nodes /one/step(nt:foxtrot mixin nt:dance,nt:art)/two/steps
+ensure nodes /one:and/step/two:and/steps
+",\
+"
+add mixin mix:one,mix:two to /thePath1,/thePath2
+add mixin mix:three, mix:four to /thePath3, /thePath4
+remove mixin mix:one,mix:two from /thePath1,/thePath2
+remove mixin mix:three, mix:four from /thePath3, /thePath4
 ",\
 "
 register namespace ( prefix ) http://prefix/v0.0.0",\
@@ -112,6 +126,12 @@ remove principal ACE for principal1,principal2
     allow jcr:addChildNodes on /apps,/content restriction(rep:glob,/cat/*,*/cat,*cat/*)
     allow jcr:something on / restriction(rep:glob)
     allow jcr:all on :repository,home(alice)
+end",\
+"
+ensure principal ACL for principal1,principal2
+    allow jcr:read on /content
+    allow jcr:addChildNodes on /apps restriction(rep:ntNames,sling:Folder,nt:unstructured)
+    allow jcr:modifyProperties on /apps restriction(rep:ntNames,sling:Folder,nt:unstructured) restriction(rep:itemNames,prop1,prop2)
 end"\
 ]
 

--- a/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.publish/org.apache.sling.jcr.repoinit.RepositoryInitializer-no-conversion-test.config
+++ b/src/test/resources/org/apache/sling/feature/cpconverter/handlers/jcr_root/apps/asd/config.publish/org.apache.sling.jcr.repoinit.RepositoryInitializer-no-conversion-test.config
@@ -65,6 +65,20 @@ delete group gr1",\
 "
 create path /test(sling:Folder)/a(nt:folder mixin mix:referenceable,mix:shareable)/b(nt:unstructured)/c(sling:Folder mixin mix:created)
 create path (sling:Folder) /test/a(nt:folder mixin mix:referenceable,mix:shareable)/b(nt:unstructured)/c( mixin mix:created)
+ensure nodes /three/four(nt:folk)/five(nt:jazz)/six
+ensure nodes (nt:x) /seven/eight/nine
+ensure nodes /one(mixin nt:art)/step(mixin nt:dance)/two/steps
+ensure nodes (nt:foxtrot) /one/step(mixin nt:dance)/two/steps
+ensure nodes /one/step(mixin nt:dance,nt:art)/two/steps
+ensure nodes /one/step(nt:foxtrot mixin nt:dance)/two/steps
+ensure nodes /one/step(nt:foxtrot mixin nt:dance,nt:art)/two/steps
+ensure nodes /one:and/step/two:and/steps
+",\
+"
+add mixin mix:one,mix:two to /thePath1,/thePath2
+add mixin mix:three, mix:four to /thePath3, /thePath4
+remove mixin mix:one,mix:two from /thePath1,/thePath2
+remove mixin mix:three, mix:four from /thePath3, /thePath4
 ",\
 "
 register namespace ( prefix ) http://prefix/v0.0.0",\
@@ -112,6 +126,12 @@ remove principal ACE for principal1,principal2
     allow jcr:addChildNodes on /apps,/content restriction(rep:glob,/cat/*,*/cat,*cat/*)
     allow jcr:something on / restriction(rep:glob)
     allow jcr:all on :repository,home(alice)
+end",\
+"
+ensure principal ACL for principal1,principal2
+    allow jcr:read on /content
+    allow jcr:addChildNodes on /apps restriction(rep:ntNames,sling:Folder,nt:unstructured)
+    allow jcr:modifyProperties on /apps restriction(rep:ntNames,sling:Folder,nt:unstructured) restriction(rep:itemNames,prop1,prop2)
 end"\
 ]
 


### PR DESCRIPTION
hi @rombert and @kwin , while searching for tickets related to sling-initial-content in jira, i stumbled across this one here. IMHO none of the new repo-init statements requires any conversion and thus they can be written out in their original form (similar to CreatePath and SetAclPrincipalBased).

i would still appreciate if you could take a careful look. thank you!