### PR TITLE
SLING-12474 - Incorrect repoinit statements generated for bundles embedded more than once at different paths

### DIFF
--- a/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
+++ b/src/main/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverter.java
@@ -412,8 +412,8 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
         requireNonNull(path, "Impossible to process a null vault package");
         requireNonNull(vaultPackage, "Impossible to process a null vault package");
 
-        if (!isSubContentPackageIncluded(path)) {
-            logger.info("Sub content-package {} is filtered out, so it won't be processed.", path);
+        if (!isSubContentPackageIncluded(vaultPackage.getId())) {
+            logger.info("Sub content-package {} at path {} is filtered out, so it won't be processed.", vaultPackage.getId(), path);
             return;
         }
 
@@ -526,8 +526,8 @@ public class ContentPackage2FeatureModelConverter extends BaseVaultPackageScanne
         });
     }
 
-    public boolean isSubContentPackageIncluded(@NotNull String path) {
-        return subContentPackages.containsValue(path);
+    public boolean isSubContentPackageIncluded(@NotNull PackageId id) {
+        return subContentPackages.containsKey(id);
     }
 
     private void process(@NotNull String entryPath, @NotNull Archive archive, @Nullable Entry entry, String runMode) throws IOException, ConverterException {

--- a/src/test/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverterTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/ContentPackage2FeatureModelConverterTest.java
@@ -35,12 +35,14 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.Properties;
 import java.util.zip.ZipFile;
-
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -58,9 +60,9 @@ import org.apache.sling.feature.Configurations;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionType;
 import org.apache.sling.feature.Feature;
-import org.apache.sling.feature.cpconverter.accesscontrol.AclManager;
 import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter.PackagePolicy;
 import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter.RunModePolicy;
+import org.apache.sling.feature.cpconverter.accesscontrol.AclManager;
 import org.apache.sling.feature.cpconverter.accesscontrol.DefaultAclManager;
 import org.apache.sling.feature.cpconverter.artifacts.LocalMavenRepositoryArtifactsDeployer;
 import org.apache.sling.feature.cpconverter.artifacts.SimpleFolderArtifactsDeployer;
@@ -73,6 +75,10 @@ import org.apache.sling.feature.io.json.FeatureJSONReader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
 
 public class ContentPackage2FeatureModelConverterTest extends AbstractConverterTest {
 
@@ -927,8 +933,8 @@ public class ContentPackage2FeatureModelConverterTest extends AbstractConverterT
         File[] contentPackages = load("test-content-package.zip", "test-content-package-2.zip");
         converter.firstPass(contentPackages);
 
-        assertTrue(converter.isSubContentPackageIncluded("/jcr_root/etc/packages/asd/test-content-0.2.zip"));
-        assertFalse(converter.isSubContentPackageIncluded("/jcr_root/etc/packages/asd/test-content.zip"));
+        assertTrue(converter.isSubContentPackageIncluded(new PackageId("asd/sample", "Asd.Retail.ui.content", "0.0.2")));
+        assertFalse(converter.isSubContentPackageIncluded(new PackageId("asd/sample", "Asd.Retail.ui.content", "0.0.1")));
     }
 
     @Test

--- a/src/test/java/org/apache/sling/feature/cpconverter/handlers/BundleEntryHandleSlingInitialContentTest.java
+++ b/src/test/java/org/apache/sling/feature/cpconverter/handlers/BundleEntryHandleSlingInitialContentTest.java
@@ -92,6 +92,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
     
     @Test
     public void testSlingInitialContent() throws Exception {
+        PackageId targetId = PackageId.fromString("io.wcm:io.wcm.handler.media-apps:1.11.6-cp2fm-converted");
         setUpArchive("/jcr_root/apps/gav/install/io.wcm.handler.media-1.11.6.jar", "io.wcm.handler.media-1.11.6.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager();
         converter.setEntryHandlersManager(handlersManager);
@@ -100,7 +101,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/gav/install/io.wcm.handler.media-1.11.6.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -133,7 +134,6 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         try (VaultPackage vaultPackage = new PackageManagerImpl().open(new File(targetFolder, "io.wcm.handler.media-apps-1.11.6-cp2fm-converted.zip"));
              Archive archive = vaultPackage.getArchive()) {
             archive.open(true);
-            PackageId targetId = PackageId.fromString("io.wcm:io.wcm.handler.media-apps:1.11.6-cp2fm-converted");
             assertEquals(targetId, vaultPackage.getId());
             Entry entry = archive.getEntry("jcr_root/apps/wcm-io/handler/media/components/global/include/responsiveImageSettings/.content.xml");
             assertNotNull("Archive does not contain expected item", entry);
@@ -177,6 +177,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testJsonI18nWithXMLFolderDescriptors() throws Exception {
+        PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
         setUpArchive("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar", "mysite.core-1.0.0-SNAPSHOT-i18n-xml-folderdescriptor.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager(Collections.emptyMap(), false, SlingInitialContentPolicy.KEEP, new BundleSlingInitialContentExtractor(), ConverterConstants.SYSTEM_USER_REL_PATH_DEFAULT);
         converter.setEntryHandlersManager(handlersManager);
@@ -190,7 +191,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -213,7 +214,6 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         try (VaultPackage vaultPackage = new PackageManagerImpl().open(new File(targetFolder, "mysite.core-apps-1.0.0-SNAPSHOT-cp2fm-converted.zip"));
              Archive archive = vaultPackage.getArchive()) {
             archive.open(true);
-            PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
             assertEquals(targetId, vaultPackage.getId());
 
             Entry jsonFileEntry = archive.getEntry("/jcr_root/apps/myinitialcontentest/test/i18n/en.json");
@@ -244,6 +244,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testSlingInitialContentWithNodeTypeAndNoDefinedParent() throws Exception {
+        PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
         setUpArchive("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar", "mysite.core-1.0.0-SNAPSHOT-slinginitialcontent-test.jar");
         
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager(Collections.emptyMap(), false, SlingInitialContentPolicy.KEEP, new BundleSlingInitialContentExtractor(), ConverterConstants.SYSTEM_USER_REL_PATH_DEFAULT);
@@ -258,7 +259,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -282,7 +283,6 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         try (VaultPackage vaultPackage = new PackageManagerImpl().open(new File(targetFolder, "mysite.core-apps-1.0.0-SNAPSHOT-cp2fm-converted.zip"));
              Archive archive = vaultPackage.getArchive()) {
             archive.open(true);
-            PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
             assertEquals(targetId, vaultPackage.getId());
             
             InputStream inputStream = archive.getInputSource(archive.getEntry("jcr_root/apps/myinitialcontentest/test/parent-with-definition/.content.xml")).getByteStream();
@@ -308,6 +308,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testSlingInitialContentWithNodeTypeAndPageJson() throws Exception {
+        PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
         setUpArchive("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar", "mysite.core-1.0.0-SNAPSHOT-pagejson.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager(Collections.emptyMap(), false, SlingInitialContentPolicy.KEEP, new BundleSlingInitialContentExtractor(), ConverterConstants.SYSTEM_USER_REL_PATH_DEFAULT);
         converter.setEntryHandlersManager(handlersManager);
@@ -321,7 +322,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -343,7 +344,6 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         try (VaultPackage vaultPackage = new PackageManagerImpl().open(new File(targetFolder, "mysite.core-apps-1.0.0-SNAPSHOT-cp2fm-converted.zip"));
              Archive archive = vaultPackage.getArchive()) {
             archive.open(true);
-            PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
             assertEquals(targetId, vaultPackage.getId());
 
             assertPageStructureFromEntry(archive, "jcr_root/apps/mysite/components/global", "homepage");
@@ -367,6 +367,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         // skip this test on windows - the special chars used in file and property names will not work on windows FS
         assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
+        PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
         setUpArchive("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar", "mysite.core-1.0.0-SNAPSHOT-specialchars-json-inputstream.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager(Collections.emptyMap(), false, SlingInitialContentPolicy.KEEP, new BundleSlingInitialContentExtractor(), ConverterConstants.SYSTEM_USER_REL_PATH_DEFAULT);
         converter.setEntryHandlersManager(handlersManager);
@@ -380,7 +381,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -402,7 +403,6 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         try (VaultPackage vaultPackage = new PackageManagerImpl().open(new File(targetFolder, "mysite.core-apps-1.0.0-SNAPSHOT-cp2fm-converted.zip"));
              Archive archive = vaultPackage.getArchive()) {
             archive.open(true);
-            PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
             assertEquals(targetId, vaultPackage.getId());
 
             //json containing a property: "fancyCharacters": "<&\"'>"
@@ -428,6 +428,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testSlingInitialContentWithNumberedEntries() throws Exception {
+        PackageId targetId = PackageId.fromString("io.wcm:io.wcm.handler.link-apps:1.7.0-cp2fm-converted");
         setUpArchive("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar", "io.wcm.handler.link-1.7.02.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager(Collections.emptyMap(), false, SlingInitialContentPolicy.KEEP, new BundleSlingInitialContentExtractor(), ConverterConstants.SYSTEM_USER_REL_PATH_DEFAULT);
         converter.setEntryHandlersManager(handlersManager);
@@ -441,7 +442,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -475,6 +476,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testSlingInitialContentWithNodeType() throws Exception {
+        PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
         setUpArchive("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar", "mysite-slinginitialcontent-nodetype-def.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager();
         converter.setEntryHandlersManager(handlersManager);
@@ -484,7 +486,7 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/mysite/install/mysite-slinginitialcontent-nodetype-def.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -513,7 +515,6 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         try (VaultPackage vaultPackage = new PackageManagerImpl().open(new File(targetFolder, "mysite.core-apps-1.0.0-SNAPSHOT-cp2fm-converted.zip")); 
             Archive archive = vaultPackage.getArchive()) {
             archive.open(true);
-            PackageId targetId = PackageId.fromString("com.mysite:mysite.core-apps:1.0.0-SNAPSHOT-cp2fm-converted");
             assertEquals(targetId, vaultPackage.getId());
             Entry entry = archive.getEntry("jcr_root/apps/myinitialcontentest/my-first-node/.content.xml");
             assertNotNull("Archive does not contain expected item", entry);
@@ -532,10 +533,11 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testSlingInitialContentContainingConfigurationExtractAndRemove() throws Exception {
+        PackageId targetId = PackageId.fromString("com.composum.nodes:composum-nodes-config-apps:2.5.3-cp2fm-converted");
         setUpArchive("/jcr_root/apps/gav/install/composum-nodes-config-2.5.3.jar", "composum-nodes-config-2.5.3.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager();
         converter.setEntryHandlersManager(handlersManager);
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/gav/install/composum-nodes-config-2.5.3.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
         props.setProperty(PackageProperties.NAME_GROUP, "io.wcm");
@@ -570,10 +572,11 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testSlingInitialContentContainingConfigurationExtractAndKeep() throws Exception {
+        PackageId targetId = PackageId.fromString("com.composum.nodes:composum-nodes-config-apps:2.5.3-cp2fm-converted");
         setUpArchive("/jcr_root/apps/gav/install/composum-nodes-config-2.5.3.jar", "composum-nodes-config-2.5.3.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager();
         converter.setEntryHandlersManager(handlersManager);
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/gav/install/composum-nodes-config-2.5.3.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
         props.setProperty(PackageProperties.NAME_GROUP, "io.wcm");
@@ -609,13 +612,14 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
 
     @Test
     public void testSlingInitialContentEscapingPropertyValues() throws Exception {
+        PackageId targetId = PackageId.fromString("com.aem632:aem-aem632-project.core-apps:0.0.1-SNAPSHOT-cp2fm-converted");
         setUpArchive("/jcr_root/apps/gav/install/aem-aem632-project.core-0.0.1-SNAPSHOT-escaping.jar", "aem-aem632-project.core-0.0.1-SNAPSHOT-escaping.jar");
         DefaultEntryHandlersManager handlersManager = new DefaultEntryHandlersManager();
         converter.setEntryHandlersManager(handlersManager);
 
         File targetFolder = tmpFolder.newFolder();
         when(converter.getArtifactsDeployer()).thenReturn(new SimpleFolderArtifactsDeployer(targetFolder));
-        when(converter.isSubContentPackageIncluded("/jcr_root/apps/gav/install/aem-aem632-project.core-0.0.1-SNAPSHOT-escaping.jar-APPLICATION")).thenReturn(true);
+        when(converter.isSubContentPackageIncluded(targetId)).thenReturn(true);
 
         VaultPackageAssembler assembler = Mockito.mock(VaultPackageAssembler.class);
         Properties props = new Properties();
@@ -639,7 +643,6 @@ public class BundleEntryHandleSlingInitialContentTest extends AbstractBundleEntr
         try (VaultPackage vaultPackage = new PackageManagerImpl().open(new File(targetFolder, "aem-aem632-project.core-apps-0.0.1-SNAPSHOT-cp2fm-converted.zip"));
              Archive archive = vaultPackage.getArchive()) {
             archive.open(true);
-            PackageId targetId = PackageId.fromString("com.aem632:aem-aem632-project.core-apps:0.0.1-SNAPSHOT-cp2fm-converted");
             assertEquals(targetId, vaultPackage.getId());
             Entry entry = archive.getEntry("jcr_root/apps/aem632/core/test/.content.xml");
             assertNotNull("Archive does not contain expected item", entry);


### PR DESCRIPTION
Switch sub content-package inclusion check to package ids.